### PR TITLE
[DODSS-796] - Endpoints for Module Questionnaire screen

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -70,11 +70,13 @@ from sqlalchemy import or_
 from flask_redoc import Redoc
 from surveys import survey_bp
 from module_questionnaire import module_questionnaire_bp
+from module_selection import module_selection_bp
 
 dod_app = Flask(__name__)
 
 dod_app.register_blueprint(survey_bp)
 dod_app.register_blueprint(module_questionnaire_bp)
+dod_app.register_blueprint(module_selection_bp)
 
 ##############################################################################
 # SET GLOBALS

--- a/flask_app/module_selection/__init__.py
+++ b/flask_app/module_selection/__init__.py
@@ -1,0 +1,3 @@
+from .routes import module_selection_bp
+
+from . import controllers

--- a/flask_app/module_selection/controllers.py
+++ b/flask_app/module_selection/controllers.py
@@ -1,0 +1,67 @@
+from flask import jsonify, request
+from .models import db, Module, ModuleStatus
+from .routes import module_selection_bp
+from .validators import UpdateModuleStatusValidator, AddModuleStatusValidator
+import json
+
+
+@module_selection_bp.route('/modules', methods=['GET'])
+def list_modules():
+    modules = Module.query.all()
+    if not modules:
+        return jsonify({'success': False, 'message': 'No modules found.'}), 404
+    return jsonify({'success': True, 'data': [module.to_dict() for module in modules]}), 200
+
+@module_selection_bp.route('/module-status', methods=['POST'])
+def add_module_status():
+    validator = AddModuleStatusValidator.from_json(request.get_json())
+
+    if "X-CSRF-Token" in request.headers:
+        validator.csrf_token.data = request.headers.get("X-CSRF-Token")
+    else:
+        return jsonify(message="X-CSRF-Token required in header"), 403
+
+    if not validator.validate():
+        return jsonify({'success': False, 'errors': validator.errors}), 422
+
+    survey_uid = validator.survey_uid.data
+    modules = validator.modules.data
+
+    for module_id in modules:
+        module = Module.query.get(module_id)
+        if not module:
+            return jsonify({'success': False, 'message': f'Module with id {module_id} does not exist.'}), 404
+
+        module_status = ModuleStatus.query.filter_by(survey_uid=survey_uid, module_id=module_id).first()
+        if not module_status:
+            module_status = ModuleStatus(survey_uid=survey_uid, module_id=module_id, config_status='Not Started')
+            db.session.add(module_status)
+
+    db.session.commit()
+    return jsonify({'success': True, 'message': 'Module status added successfully.'}), 200
+
+@module_selection_bp.route('/module-status/<int:survey_uid>', methods=['GET'])
+def get_module_status(survey_uid):
+    module_status = ModuleStatus.query.filter_by(survey_uid=survey_uid).all()
+    return jsonify({'success': True, 'data': [status.to_dict() for status in module_status]}), 200
+
+@module_selection_bp.route('/modules/<int:module_id>/status/<int:survey_uid>', methods=['PUT'])
+def update_module_status(module_id, survey_uid):
+    module_status = ModuleStatus.query.filter_by(module_id=module_id, survey_uid=survey_uid).first()
+    validator = UpdateModuleStatusValidator.from_json(request.get_json())
+
+    if "X-CSRF-Token" in request.headers:
+        validator.csrf_token.data = request.headers.get("X-CSRF-Token")
+    else:
+        return jsonify(message="X-CSRF-Token required in header"), 403
+
+    if not validator.validate(module_status):
+        return jsonify({'success': False, 'message': validator.errors}), 422
+
+    module_status.config_status = validator.config_status.data
+
+    db.session.commit()
+
+    return jsonify({'success': True, 'data': module_status.to_dict()}), 200
+
+

--- a/flask_app/module_selection/models.py
+++ b/flask_app/module_selection/models.py
@@ -1,0 +1,49 @@
+from flask_app.database import db
+from flask_app.surveys.models import Survey
+class Module(db.Model):
+    __tablename__ = 'modules'
+    __table_args__ = {
+        'extend_existing': True,
+        'schema': 'config_sandbox',
+    }
+
+    module_id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String, unique=True, nullable=False)
+    optional = db.Column(db.Boolean, nullable=False)
+
+    module_status = db.relationship("ModuleStatus", back_populates="module")
+
+    def __init__(self, name, optional):
+        self.name = name
+        self.optional = optional
+
+    def to_dict(self):
+        return {
+            'module_id': self.module_id,
+            'name': self.name,
+            'optional': self.optional
+        }
+
+class ModuleStatus(db.Model):
+    __tablename__ = 'module_status'
+    __table_args__ = {
+        'extend_existing': True,
+        'schema': 'config_sandbox',
+    }
+
+    survey_uid = db.Column(db.Integer, db.ForeignKey(Survey.survey_uid), primary_key=True)
+    module_id = db.Column(db.Integer, db.ForeignKey(Module.module_id), primary_key=True)
+    config_status = db.Column(db.String, nullable=False, default='Not Started', server_default='Not Started')
+
+    module = db.relationship(Module, back_populates="module_status")
+
+    def __init__(self, survey_uid, module_id, config_status):
+        self.survey_uid = survey_uid
+        self.module_id = module_id
+        self.config_status = config_status
+    def to_dict(self):
+        return {
+            'survey_uid': self.survey_uid,
+            'module_id': self.module_id,
+            'config_status': self.config_status
+        }

--- a/flask_app/module_selection/routes.py
+++ b/flask_app/module_selection/routes.py
@@ -1,0 +1,4 @@
+from flask import Blueprint
+
+module_selection_bp = Blueprint('module_selection', __name__, url_prefix='/api')
+# Define your routes here

--- a/flask_app/module_selection/validators.py
+++ b/flask_app/module_selection/validators.py
@@ -1,0 +1,25 @@
+from wtforms import  StringField, validators, FieldList
+from flask_wtf import FlaskForm
+
+class UpdateModuleStatusValidator(FlaskForm):
+    config_status = StringField(validators=[validators.DataRequired()])
+
+    def validate(self, status):
+        if not super().validate():
+            return False
+
+        if status is None:
+            self.errors['status'] = ['Module status not found.']
+            return False
+
+        return True
+
+class AddModuleStatusValidator(FlaskForm):
+    survey_uid = StringField(validators=[validators.DataRequired()])
+    modules = FieldList(StringField(), validators=[validators.DataRequired()])
+
+    def validate(self):
+        if not super().validate():
+            return False
+
+        return True

--- a/flask_app/openapi/surveystream.yml
+++ b/flask_app/openapi/surveystream.yml
@@ -83,6 +83,9 @@ x-tagGroups:
     tags:
       - Surveys
       - Forms
+  - name: Module Selection
+    tags:
+      - Module Selection
   - name: Enumerators
     tags:
       - Enumerators
@@ -744,6 +747,225 @@ paths:
                   error:
                     type: string
                     example: Survey already exists
+  /modules:
+    get:
+      tags:
+        - Module Selection
+      summary: Get all modules
+      description: Get a list of all modules
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+                description: Indicates if the request was successful
+              data:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    module_id:
+                      type: integer
+                      format: int64
+                      description: ID of the module
+                    name:
+                      type: string
+                      description: Name of the module
+                    optional:
+                      type: boolean
+                      description: Indicates if the module is optional
+        '404':
+          description: Not Found
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                description: Error message
+                example: No modules found.
+  /module-status:
+    post:
+      tags:
+        - Module Selection
+      summary: Add selected modules for a particular survey
+      description: Add selected modules for a particular survey, with a default config_status of `not started`.
+      requestBody:
+        description: JSON object containing survey ID and list of module IDs
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                survey_id:
+                  type: integer
+                  description: ID of the survey to add module status for
+                modules:
+                  type: array
+                  description: List of module IDs
+                  example: [ 1,2,3 ]
+      responses:
+        '200':
+          description: Module added successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Indicates if the request was successful
+                    example: true
+                  message:
+                    type: string
+                    description: Module status added successfully
+                    example: { }
+        '400':
+          description: Invalid request body or missing required fields
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Indicates if the request was successful
+                    example: false
+                  message:
+                    type: string
+                    description: Error message
+                    example: "Both survey_id and modules are required."
+  /modules/{module_id}/status/{survey_uid}:
+    put:
+      tags:
+        - Module Selection
+      summary: Update status of a module for a specific survey
+      parameters:
+        - in: path
+          name: module_id
+          schema:
+            type: integer
+          required: true
+          description: The ID of the module to update the status for
+        - in: path
+          name: survey_uid
+          schema:
+            type: integer
+          required: true
+          description: The ID of the survey to update the status for
+        - in: body
+          name: status
+          description: The new status to set for the module
+          schema:
+            type: object
+            properties:
+              config_status:
+                type: string
+                enum: [ Done, In Progress, Not Started, Error ]
+          required: true
+      responses:
+        '200':
+          description: Successfully updated module status for survey
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    example:
+                      survey_uid: 1
+                      module_id: 2
+                      config_status: Done
+        '400':
+          description: Bad request. Either module_id or survey_uid or status missing in the request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Both module_id and survey_uid and status are required.
+        '404':
+          description: The requested module or survey was not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: The requested module or survey was not found
+  /module-status/{survey_uid}:
+    get:
+      tags:
+        - Module Selection
+      summary: Get module status for a survey
+      description: |
+        Returns the completion status of all modules for a given survey.
+        - `survey_uid`: ID of the survey for which to retrieve module status.
+        **Note**: If the survey ID is not found, a 404 error will be returned.
+      parameters:
+        - name: survey_uid
+          in: path
+          description: ID of the survey
+          required: true
+          schema:
+            type: integer
+
+      responses:
+        '200':
+          description: Returns the completion status of all modules for a given survey.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Indicates whether the request was successful
+                  data:
+                    type: array
+                    description: List of modules and their completion status for the given survey
+                    items:
+                      type: object
+                      properties:
+                        module_id:
+                          type: integer
+                          description: ID of the module
+                        survey_uid:
+                          type: integer
+                          description: ID of the survey
+                        config_status:
+                          type: string
+                          description: Completion status of the module for the given survey
+                          enum: [ 'Done', 'In Progress', 'Not Started', 'Error' ]
+        '404':
+          description: The specified survey ID was not found.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Indicates whether the request was successful
+                  message:
+                    type: string
+                    description: Error message indicating that the specified survey ID was not found.
   /forms/{form_uid}:
     get:
       summary: Get forms


### PR DESCRIPTION
## [DODSS-796] - Endpoints for Module Questionnaire screen

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DODSS-796

## Description, Motivation and Context

Adding Module Questionnaire module with a GET and PUT endpoint. The endpoint route is `/api/module-questionnaire/<int:survey_uid>`

- GET endpoint: Get module questionnaire responses for a survey
- PUT endpoint: Save module questionnaire responses for a survey

Note: I have added the payload structure to `models/form_models.py` file which is a file in the old file structure. We could move this to a file within `module_questionnaire` folder instead.

## How Has This Been Tested?
Using Postman

## UI Changes
Added the endpoints to API docs as well as shown:
<img width="1452" alt="Screenshot 2023-04-27 at 12 47 32 PM" src="https://user-images.githubusercontent.com/51594058/234788139-a3d1df13-9f53-40cb-82bd-137b40b78fe4.png">

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[1]: http://chris.beams.io/posts/git-commit/

[DODSS-796]: https://idinsight.atlassian.net/browse/DODSS-796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ