### PR TITLE
[DODSS-858] Add makefile command to set AWS_PROFILE when logging into AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,11 @@ $(eval DEV_ACCOUNT=453207568606)
 
 
 login:
+	export AWS_PROFILE=surveystream_dev
 	@aws sso login --profile surveystream_dev
 
 image:
-	@docker build -f Dockerfile.api --rm --build-arg NAME=$(BACKEND_NAME) --build-arg PORT=$(BACKEND_PORT) --platform=linux/amd64 -t $(BACKEND_NAME):$(VERSION) .
+	@docker build -f Dockerfile.api --rm --build-arg NAME=$(BACKEND_NAME) --build-arg PORT=$(BACKEND_PORT) --no-cache --platform=linux/amd64 -t $(BACKEND_NAME):$(VERSION) .
 
 db-tunnel:
 	# Open a connection to the remote db via the bastion host


### PR DESCRIPTION
## [DODSS-858] Add makefile command to set AWS_PROFILE when logging into AWS

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DODSS-858

## Description, Motivation and Context

Running the back end container locally requires having `AWS_PROFILE` set to `surveystream_dev`. This is needed for both the `make container-up` and `make run-test-e2e` commands. I am adding this line to the `make login` target so that it does not need to be maintained in multiple targets that run local containers.

## How Has This Been Tested?
- Ran the e2e tests

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[1]: http://chris.beams.io/posts/git-commit/

[DODSS-858]: https://idinsight.atlassian.net/browse/DODSS-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ