### PR TITLE
[DODSS-843] Add /timezones endpoint to API documentation

### DIFF
--- a/app/blueprints/docs/surveystream.yml
+++ b/app/blueprints/docs/surveystream.yml
@@ -2569,3 +2569,32 @@ paths:
           description: X-CSRF-Token required in header
         '422':
           description: Form errors
+  /timezones:
+    get:
+      summary: Get the list of postgres timezones
+      tags:
+        - Misc
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    description: List of postgres timezones
+                    items:
+                      type: object
+                      description: Postgres timezone object
+                      properties:
+                        name:
+                          type: string
+                          description: Postgres timezone name
+                        abbrev:
+                          type: string
+                          description: Postgres timezone abbreviation
+                        utc_offset:
+                          type: string
+                          description: Postgres timezone UTC offset


### PR DESCRIPTION
## [DODSS-843] Add /timezones endpoint to API documentation

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DODSS-843

## Description, Motivation and Context

I missed adding the `/api/timezones` endpoint to the OpenAPI documentation in the main PR for this ticket. Adding it here.

## How Has This Been Tested?

Tests are passing

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [x] I have written [good commit messages][1]
- [x] I have updated the README file (if applicable)
- [x] I have updated affected documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/

[DODSS-843]: https://idinsight.atlassian.net/browse/DODSS-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ