### PR TITLE
[DODSS-945 & DODSS-946] Debug Flask errors

### DIFF
--- a/app/blueprints/surveys/controllers.py
+++ b/app/blueprints/surveys/controllers.py
@@ -11,6 +11,7 @@ from .validators import (
 )
 from app.utils.utils import logged_in_active_user_required
 
+
 @surveys_bp.route("", methods=["GET"])
 @logged_in_active_user_required
 def get_all_surveys():
@@ -68,7 +69,9 @@ def create_survey():
                 default_config_status = ModuleStatus(
                     survey_uid=survey.survey_uid,
                     module_id=module.module_id,
-                    config_status="In Progress" if module.name == "Basic information" else "Not Started"
+                    config_status="In Progress"
+                    if module.name == "Basic information"
+                    else "Not Started",
                 )
                 db.session.add(default_config_status)
 
@@ -100,26 +103,30 @@ def get_survey_config_status(survey_uid):
     survey = Survey.query.filter_by(survey_uid=survey_uid).first()
     if survey is None:
         return jsonify({"error": "Survey not found"}), 404
-    
-    config_status = db.session.query(
-        Module.module_id,
-        Module.name,
-        ModuleStatus.config_status,
-        Module.optional,
-        Survey.config_status.label("overall_status")
-    ).join(
-        Module,
-        ModuleStatus.module_id == Module.module_id,
-    ).join(
-        Survey,
-        ModuleStatus.survey_uid == Survey.survey_uid,
-    ).filter(
-        ModuleStatus.survey_uid == survey_uid
-    ).all()
-        
+
+    config_status = (
+        db.session.query(
+            Module.module_id,
+            Module.name,
+            ModuleStatus.config_status,
+            Module.optional,
+            Survey.config_status.label("overall_status"),
+        )
+        .join(
+            Module,
+            ModuleStatus.module_id == Module.module_id,
+        )
+        .join(
+            Survey,
+            ModuleStatus.survey_uid == Survey.survey_uid,
+        )
+        .filter(ModuleStatus.survey_uid == survey_uid)
+        .all()
+    )
+
     data = {}
     for status in config_status:
-        overall_status = status["overall_status"]
+        data["overall_status"] = status["overall_status"]
         if status.optional is False:
             if status.name in ["Basic information", "Module selection"]:
                 data[status.name] = {"status": status.config_status}
@@ -127,11 +134,8 @@ def get_survey_config_status(survey_uid):
                 if "Survey information" not in list(data.keys()):
                     data["Survey information"] = []
                 data["Survey information"].append(
-                    {
-                        "name": status.name,
-                        "status": status.config_status
-                    }
-                ) 
+                    {"name": status.name, "status": status.config_status}
+                )
         else:
             if "Module configuration" not in list(data.keys()):
                 data["Module configuration"] = []
@@ -139,10 +143,9 @@ def get_survey_config_status(survey_uid):
                 {
                     "module_id": status.module_id,
                     "name": status.name,
-                    "status": status.config_status
+                    "status": status.config_status,
                 }
             )
-    data["overall_status"] = overall_status
 
     response = {"success": True, "data": data}
     return jsonify(response), 200
@@ -206,7 +209,7 @@ def delete_survey(survey_uid):
     survey = Survey.query.filter_by(survey_uid=survey_uid).first()
     if survey is None:
         return jsonify({"error": "Survey not found"}), 404
-    
+
     ModuleStatus.query.filter(ModuleStatus.survey_uid == survey_uid).delete()
     db.session.delete(survey)
 

--- a/db/1-config-schema.sql
+++ b/db/1-config-schema.sql
@@ -64,8 +64,8 @@ CREATE TABLE config_sandbox.module_questionnaire (
 	supervisor_hierarchy_exists BOOLEAN,
 	reassignment_required BOOLEAN,
 	assignment_process VARCHAR CHECK (assignment_process IN ('Manual','Random')),
-	supervisor_enumerator_relation VARCHAR,
-	language_lacation_mapping BOOLEAN
+	supervisor_surveyor_relation VARCHAR,
+	language_location_mapping BOOLEAN
 );
 
 /*


### PR DESCRIPTION
## [DODSS-945 & DODSS-946] Debug Flask errors

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DODSS-945
Fixes: https://idinsight.atlassian.net/browse/DODSS-946

## Description, Motivation and Context

This PR fixes 3 Sentry bugs. 

Ticket DODSS-945 corresponds to two issues where the database .sql schema file was out of sync with the Flask models. The .sql file has been updated and changes manually done on the staging db.

Ticket DODSS-946 corresponds to an issue where the overall survey status was being assigned to the payload even if no records existed, which was leading to an error. The overall status is now only being added to the payload if records are returned from the db.

## How Has This Been Tested?
- @j-meher to confirm that the module questionnaire screens are now working (ie, no longer raising errors)
- The survey status error is a little confusing because as long as the call to `POST /api/surveys` was successful, the query inside the `GET /api/surveys/:survey_uid:/config-status` endpoint should return >0 rows, and calling the endpoint against a non-existent survey should return `404`. The error perhaps occurred do to a partial/unsuccessful survey creation step. The fix implemented here will make the endpoint robust to this edge case.

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [x] I have written [good commit messages][1]
- [x] I have updated the README file (if applicable)
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/