### PR TITLE
[DODSS-961] - Fetch module status based on presence of saved data in the tables

### DIFF
--- a/app/blueprints/surveys/controllers.py
+++ b/app/blueprints/surveys/controllers.py
@@ -161,9 +161,9 @@ def get_survey_config_status(survey_uid):
     locations = GeoLevel.query.filter_by(survey_uid=survey_uid).first()
 
     if survey is not None:
-        data["Basic information"] = "In Progress"
+        data["Basic information"]["status"] = "In Progress"
     if optional_module_flag:
-        data["Module selection"] = "In Progress"
+        data["Module selection"]["status"] = "In Progress"
     
     for item in data["Survey information"]:
         if item["name"] == "SurveyCTO information":


### PR DESCRIPTION
## [DODSS-961] - Fetch module status based on presence of saved data in the tables

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DODSS-961

Currently we don't have a mechanism to update the `module_status` table from each screen on the WebApp. Hence, the config states screen shows 'Not started' even though the configuration for the module has started. As a fix, in this PR we are updating the `surveys/<int:survey_uid>/config-status` endpoint to look for saved data in the tables corresponding to each table and update status to `In Progress` when there is any data. 

## How Has This Been Tested?
Test cases are passing. Also tested some surveys on postman

## To-do before merge

- [ ] Check with @edodge on a better way to import ParentForm model to the file without circular import errors 

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have updated the automated tests (if applicable)
- [ ] I have written [good commit messages][1]
- [ ] I have updated the README file (if applicable)
- [ ] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/

[DODSS-961]: https://idinsight.atlassian.net/browse/DODSS-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ