### PR TITLE
Remove nullable false from revisit and survey status

### DIFF
--- a/app/blueprints/forms/models.py
+++ b/app/blueprints/forms/models.py
@@ -161,8 +161,8 @@ class SCTOQuestionMapping(db.Model):
         primary_key=True,
         nullable=False,
     )
-    survey_status = db.Column(db.String(), nullable=False)
-    revisit_section = db.Column(db.String(), nullable=False)
+    survey_status = db.Column(db.String())
+    revisit_section = db.Column(db.String())
     target_id = db.Column(db.String(), nullable=False)
     enumerator_id = db.Column(db.String(), nullable=False)
     locations = db.Column(JSONB)


### PR DESCRIPTION
Removing non-nullable condition from survey status and revisit sections because:
- Survey Status is a required field only when productivity tracker is used
- Revisit sections is a required field only when assignments module is used