### PR TITLE
[SS-1082] BUGFIX: Error thrown when user is in session but not in database

### DIFF
--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -1,5 +1,5 @@
 from flask import jsonify, session, current_app
-from flask_login import login_required
+from flask_login import login_required, logout_user
 from functools import wraps
 from app import db
 from app.blueprints.auth.models import User
@@ -64,7 +64,10 @@ def logged_in_active_user_required(f):
                     .filter(User.user_uid == user_uid)
                     .one_or_none()
                 )
-                if user is not None and user.is_active() is False:
+                if user is None:
+                    logout_user()
+                    return jsonify(message="UNAUTHORIZED"), 401
+                if user.is_active() is False:
                     return jsonify(message="INACTIVE_USER"), 403
 
         return login_required(f)(*args, **kwargs)

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -91,3 +91,16 @@ def load_reference_data(filename_stub):
         reference_data = json.load(json_file)
 
     return reference_data
+
+
+def delete_user(app, db, email):
+    """
+    Delete a user directly in the database. Needed to set up certain tests.
+    """
+
+    with app.app_context():
+        db.session.execute(
+            "DELETE FROM webapp.users WHERE email=:email",
+            {"email": email},
+        )
+        db.session.commit()


### PR DESCRIPTION
# [SS-1082] BUGFIX: Error thrown when user is in session but not in database

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1082

## Description, Motivation and Context

https://idinsight.sentry.io/issues/4347278834/?project=4505070237319168

While migrating the Callisto db on staging, someone attempted to access the web app. Their user info was still in the session but the users data hadn't been copied over yet to the new db so an error was thrown when checking their `active` status against the db. This PR adds a check that the user can be found in the database before calling any methods on their user object. If a user is not found in the db, they will be logged out of the session and a `401 Unauthorized` returned.

## How Has This Been Tested?

A test case has been added to check for this scenario.

## Checklist:

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[1]: http://chris.beams.io/posts/git-commit/

[SS-1082]: https://idinsight.atlassian.net/browse/SS-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ