### PR TITLE
[SS-1085] Bugfix: Error on Inserting Module Questionnaire

### DIFF
--- a/app/blueprints/module_questionnaire/controllers.py
+++ b/app/blueprints/module_questionnaire/controllers.py
@@ -23,7 +23,6 @@ def get_survey_module_questionnaire(survey_uid):
 
 @module_questionnaire_bp.route("/<int:survey_uid>", methods=["PUT"])
 def update_survey_module_questionnaire(survey_uid):
-
     validator = ModuleQuestionnaireForm.from_json(request.get_json())
 
     if "X-CSRF-Token" in request.headers:
@@ -32,7 +31,6 @@ def update_survey_module_questionnaire(survey_uid):
         return jsonify(message="X-CSRF-Token required in header"), 403
 
     if validator.validate():
-
         # do upsert
         statement = (
             pg_insert(ModuleQuestionnaire)
@@ -47,7 +45,7 @@ def update_survey_module_questionnaire(survey_uid):
                 language_location_mapping=validator.language_location_mapping.data,
             )
             .on_conflict_do_update(
-                constraint="module_questionnaire_pkey",
+                constraint="pk_module_questionnaire",
                 set_={
                     "target_assignment_criteria": validator.target_assignment_criteria.data,
                     "supervisor_assignment_criteria": validator.supervisor_assignment_criteria.data,

--- a/tests/unit/test_module_questionnaire.py
+++ b/tests/unit/test_module_questionnaire.py
@@ -1,0 +1,98 @@
+import jsondiff
+import pytest
+import re
+
+
+@pytest.mark.module_questionnaire
+class TestModuleQuestionnaire:
+    @pytest.fixture()
+    def create_survey(self, client, login_test_user, csrf_token, test_user_credentials):
+        """
+        Insert new survey as a setup step for the survey tests
+        """
+
+        payload = {
+            "survey_id": "test_survey",
+            "survey_name": "Test Survey",
+            "survey_description": "A test survey",
+            "project_name": "Test Project",
+            "surveying_method": "in-person",
+            "irb_approval": "Yes",
+            "planned_start_date": "2021-01-01",
+            "planned_end_date": "2021-12-31",
+            "state": "Draft",
+            "config_status": "In Progress - Configuration",
+            "created_by_user_uid": test_user_credentials["user_uid"],
+        }
+
+        response = client.post(
+            "/api/surveys",
+            query_string={"user_uid": 3},
+            json=payload,
+            content_type="application/json",
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 201
+
+        yield
+
+    @pytest.fixture()
+    def create_module_questionnaire(
+        self, client, login_test_user, csrf_token, test_user_credentials, create_survey
+    ):
+        """
+        Insert new module_questionnaire as a setup step for the module_questionnaire tests
+        """
+
+        payload = {
+            "assignment_process": "Manual",
+            "language_location_mapping": False,
+            "reassignment_required": False,
+            "supervisor_assignment_criteria": ["Gender"],
+            "supervisor_hierarchy_exists": False,
+            "supervisor_surveyor_relation": "1:many",
+            "survey_uid": 1,
+            "target_assignment_criteria": ["Location of surveyors"],
+        }
+
+        response = client.put(
+            "/api/module-questionnaire/1",
+            json=payload,
+            content_type="application/json",
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+
+        yield
+
+    def test_create_module_questionnaire(
+        self,
+        client,
+        login_test_user,
+        create_module_questionnaire,
+        test_user_credentials,
+    ):
+        """
+        Test that the module_questionnaire is inserted correctly
+        """
+
+        # Test the survey was inserted correctly
+        response = client.get("/api/module-questionnaire/1")
+        assert response.status_code == 200
+
+        expected_response = {
+            "data": {
+                "assignment_process": "Manual",
+                "language_location_mapping": False,
+                "reassignment_required": False,
+                "supervisor_assignment_criteria": ["Gender"],
+                "supervisor_hierarchy_exists": False,
+                "supervisor_surveyor_relation": "1:many",
+                "survey_uid": 1,
+                "target_assignment_criteria": ["Location of surveyors"],
+            },
+            "success": True,
+        }
+
+        checkdiff = jsondiff.diff(expected_response, response.json)
+        assert checkdiff == {}


### PR DESCRIPTION
# [SS-1085] Bugfix: Error on Inserting Module Questionnaire

## Ticket

Fixes: 
https://idinsight.atlassian.net/browse/SS-1085
https://idinsight.atlassian.net/browse/DODSSPB-8

Sentry error:
https://idinsight.sentry.io/issues/4355650877/?alert_rule_id=14186375&alert_type=issue&project=4505070237319168

## Description, Motivation and Context

Flask threw an error on a valid `PUT` request to `/module-questionnaire`. On investigation, this is happened as a side effect of the shift to `Flask-Migrate`. The database call in this method does an upsert while referring to the primary key name of the table. However, the default naming for the primary key changed when shifting to `Flask-Migrate`. There were no unit tests for the endpoint so the issue was not caught previously.

## How Has This Been Tested?

- I have added a basic unit test for the `/module-questionnaire` endpoint that is passing.

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have updated the automated tests (if applicable)

[1]: http://chris.beams.io/posts/git-commit/

[SS-1085]: https://idinsight.atlassian.net/browse/SS-1085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ