### PR TITLE
changed instance id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ image:
 data-db-tunnel:
 	# Open a connection to the remote db via the bastion host
 	@aws ssm start-session \
-	--target i-0c08ac05a9796bc30 \
+	--target i-0ddd10471f2a098be \
 	--profile surveystream_dev \
 	--region ap-south-1 \
 	--document-name AWS-StartPortForwardingSession \
@@ -26,7 +26,7 @@ data-db-tunnel:
 web-db-tunnel:
 	# Open a connection to the remote db via the bastion host
 	@aws ssm start-session \
-	--target i-0c08ac05a9796bc30 \
+	--target i-0ddd10471f2a098be \
 	--profile surveystream_dev \
 	--region ap-south-1 \
 	--document-name AWS-StartPortForwardingSession \


### PR DESCRIPTION
## Fix: Change Bastion Host Instance ID


## Description, Motivation and Context

The bastion EC2 was recreated hence the instance id has changed. This affects the connection to the dev database.