### PR TITLE
[BUGFIX] Add login decorator for enumerators and targets routes

### DIFF
--- a/app/blueprints/enumerators/controllers.py
+++ b/app/blueprints/enumerators/controllers.py
@@ -52,6 +52,7 @@ import binascii
 
 
 @enumerators_bp.route("", methods=["POST"])
+@logged_in_active_user_required
 def upload_enumerators():
     """
     Method to validate the uploaded enumerators file and save it to the database
@@ -359,6 +360,7 @@ def upload_enumerators():
 
 
 @enumerators_bp.route("", methods=["GET"])
+@logged_in_active_user_required
 def get_enumerators():
     """
     Method to retrieve the enumerators information from the database
@@ -533,6 +535,7 @@ def get_enumerators():
 
 
 @enumerators_bp.route("/<int:enumerator_uid>", methods=["GET"])
+@logged_in_active_user_required
 def get_enumerator(enumerator_uid):
     """
     Method to retrieve an enumerator from the database
@@ -560,6 +563,7 @@ def get_enumerator(enumerator_uid):
 
 
 @enumerators_bp.route("/<int:enumerator_uid>", methods=["PUT"])
+@logged_in_active_user_required
 def update_enumerator(enumerator_uid):
     """
     Method to update an enumerator in the database
@@ -642,6 +646,7 @@ def update_enumerator(enumerator_uid):
 
 
 @enumerators_bp.route("/<int:enumerator_uid>", methods=["DELETE"])
+@logged_in_active_user_required
 def delete_enumerator(enumerator_uid):
     """
     Method to delete an enumerator from the database
@@ -879,6 +884,7 @@ def delete_enumerator(enumerator_uid):
 
 
 @enumerators_bp.route("/<int:enumerator_uid>/roles/locations", methods=["PUT"])
+@logged_in_active_user_required
 def update_enumerator_role(enumerator_uid):
     """
     Method to update an existing enumerator's role-location in the database
@@ -1085,6 +1091,7 @@ def update_enumerator_role(enumerator_uid):
 
 # Patch method to update an enumerator's status
 @enumerators_bp.route("/<int:enumerator_uid>/roles/status", methods=["PATCH"])
+@logged_in_active_user_required
 def update_enumerator_status(enumerator_uid):
     """
     Method to update an enumerator's status
@@ -1146,6 +1153,7 @@ def update_enumerator_status(enumerator_uid):
 
 
 @enumerators_bp.route("/<int:enumerator_uid>/roles", methods=["GET"])
+@logged_in_active_user_required
 def get_enumerator_roles(enumerator_uid):
     """
     Method to get an enumerator's roles from the database
@@ -1253,6 +1261,7 @@ def get_enumerator_roles(enumerator_uid):
 
 # Patch method to bulk update enumerator details
 @enumerators_bp.route("", methods=["PATCH"])
+@logged_in_active_user_required
 def bulk_update_enumerators_custom_fields():
     """
     Method to bulk update enumerators
@@ -1385,6 +1394,7 @@ def bulk_update_enumerators_custom_fields():
 
 
 @enumerators_bp.route("/roles/locations", methods=["PUT"])
+@logged_in_active_user_required
 def bulk_update_enumerators_role_locations():
     """
     Method to bulk update enumerators' locations for a given role
@@ -1503,6 +1513,7 @@ def bulk_update_enumerators_role_locations():
 
 
 @enumerators_bp.route("/column-config", methods=["PUT"])
+@logged_in_active_user_required
 def update_enumerator_column_config():
     """
     Method to update enumerators' column configuration
@@ -1573,6 +1584,7 @@ def update_enumerator_column_config():
 
 
 @enumerators_bp.route("/column-config", methods=["GET"])
+@logged_in_active_user_required
 def get_enumerator_column_config():
     """
     Method to get enumerators' column configuration

--- a/app/blueprints/targets/controllers.py
+++ b/app/blueprints/targets/controllers.py
@@ -41,6 +41,7 @@ import binascii
 
 
 @targets_bp.route("", methods=["POST"])
+@logged_in_active_user_required
 def upload_targets():
     """
     Method to validate the uploaded targets file and save it to the database
@@ -331,6 +332,7 @@ def upload_targets():
 
 
 @targets_bp.route("", methods=["GET"])
+@logged_in_active_user_required
 def get_targets():
     """
     Method to retrieve the targets information from the database
@@ -509,6 +511,7 @@ def get_targets():
 
 
 @targets_bp.route("/<int:target_uid>", methods=["GET"])
+@logged_in_active_user_required
 def get_target(target_uid):
     """
     Method to retrieve a target from the database
@@ -622,6 +625,7 @@ def get_target(target_uid):
 
 
 @targets_bp.route("/<int:target_uid>", methods=["PUT"])
+@logged_in_active_user_required
 def update_target(target_uid):
     """
     Method to update a target in the database
@@ -746,6 +750,7 @@ def update_target(target_uid):
 
 
 @targets_bp.route("/<int:target_uid>", methods=["DELETE"])
+@logged_in_active_user_required
 def delete_target(target_uid):
     """
     Method to delete a target from the database
@@ -767,6 +772,7 @@ def delete_target(target_uid):
 
 # Patch method to bulk update enumerator details
 @targets_bp.route("", methods=["PATCH"])
+@logged_in_active_user_required
 def bulk_update_targets():
     """
     Method to bulk update enumerators
@@ -966,6 +972,7 @@ def bulk_update_targets():
 
 
 @targets_bp.route("/column-config", methods=["PUT"])
+@logged_in_active_user_required
 def update_target_column_config():
     """
     Method to update targets' column configuration
@@ -1047,6 +1054,7 @@ def update_target_column_config():
 
 
 @targets_bp.route("/column-config", methods=["GET"])
+@logged_in_active_user_required
 def get_target_column_config():
     """
     Method to get targets' column configuration


### PR DESCRIPTION
# [BUGFIX] Add login decorator for enumerators and targets routes

## Description, Motivation and Context

The enumerators and targets routes were missing the `@logged_in_active_user_required` decorator. This PR adds the decorator to all the routes for those endpoints.

## How Has This Been Tested?

Test cases are passing

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [x] I have updated the automated tests (if applicable)
- [x] I have updated the README file (if applicable)
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/