### PR TITLE
[DDSSPB-47] Fix column references and add enumerator type checks

### DIFF
--- a/app/blueprints/targets/controllers.py
+++ b/app/blueprints/targets/controllers.py
@@ -278,14 +278,14 @@ def upload_targets():
         # Add the language if it exists
         if hasattr(column_mapping, "language"):
             col_index = (
-                targets_upload.targets_df.columns.get_loc("language") + 1
+                targets_upload.targets_df.columns.get_loc(column_mapping.language) + 1
             )  # Add 1 to the index to account for the df index
             target_dict["language"] = row[col_index]
 
         # Add the gender if it exists
         if hasattr(column_mapping, "gender"):
             col_index = (
-                targets_upload.targets_df.columns.get_loc("gender") + 1
+                targets_upload.targets_df.columns.get_loc(column_mapping.gender) + 1
             )  # Add 1 to the index to account for the df index
             target_dict["gender"] = row[col_index]
 

--- a/app/blueprints/targets/utils.py
+++ b/app/blueprints/targets/utils.py
@@ -196,7 +196,7 @@ class TargetsUpload:
 
         # Non-nullable columns should contain no blank fields
         non_null_columns = [
-            "target_id",
+            column_mapping.target_id,
         ]
 
         if hasattr(column_mapping, "location_id_column"):
@@ -277,7 +277,7 @@ class TargetsUpload:
 
         # The file should have no duplicate target IDs
         duplicates_df = self.targets_df[
-            self.targets_df.duplicated(subset="target_id", keep=False)
+            self.targets_df.duplicated(subset=column_mapping.target_id, keep=False)
         ]
         if len(duplicates_df) > 0:
             record_errors["summary_by_error_type"].append(

--- a/tests/unit/data/file_uploads/sample_enumerators_small.csv
+++ b/tests/unit/data/file_uploads/sample_enumerators_small.csv
@@ -1,4 +1,4 @@
-enumerator_id,name,email,mobile_primary,language,home_address,gender,enumerator_type,district_id,mobile_secondary,age
+enumerator_id1,name1,email1,mobile_primary1,language1,home_address1,gender1,enumerator_type1,district_id1,mobile_secondary1,age1
 0294612,Eric Dodge,eric.dodge@idinsight.org,0123456789,English,my house,Male,surveyor,1,1123456789,1
 0294613,Jahnavi Meher,jahnavi.meher@idinsight.org,0123456789,Telugu,my house,Female,surveyor,1,1123456789,2
 0294614,Jay Prakash,jay.prakash@idinsight.org,0123456789,Hindi,my house,Male,monitor,1,1123456789,3

--- a/tests/unit/data/file_uploads/sample_targets_small.csv
+++ b/tests/unit/data/file_uploads/sample_targets_small.csv
@@ -1,3 +1,3 @@
-target_id,language,gender,psu_id,name,mobile_primary,address
+target_id1,language1,gender1,psu_id1,name1,mobile_primary1,address1
 1,Telugu,Male,17101102,Anil,1234567890,Hyderabad
 2,Hindi,Female,17101102,Anupama,1234567891,South Delhi

--- a/tests/unit/test_targets.py
+++ b/tests/unit/test_targets.py
@@ -283,22 +283,22 @@ class TestTargets:
         # Try to upload the targets csv
         payload = {
             "column_mapping": {
-                "target_id": "target_id",
-                "language": "language",
-                "gender": "gender",
-                "location_id_column": "psu_id",
+                "target_id": "target_id1",
+                "language": "language1",
+                "gender": "gender1",
+                "location_id_column": "psu_id1",
                 "custom_fields": [
                     {
                         "field_label": "Mobile no.",
-                        "column_name": "mobile_primary",
+                        "column_name": "mobile_primary1",
                     },
                     {
                         "field_label": "Name",
-                        "column_name": "name",
+                        "column_name": "name1",
                     },
                     {
                         "field_label": "Address",
-                        "column_name": "address",
+                        "column_name": "address1",
                     },
                 ],
             },


### PR DESCRIPTION
# [DDSSPB-47] Fix column references and add enumerator type checks

## Ticket

Fixes: https://idinsight.atlassian.net/jira/software/c/projects/DDSSPB/issues/DDSSPB-47

## Description, Motivation and Context

This PR fixes a bug that was causing a 500 error when uploading targets and enumerators csv data through the web app. The source of the bug was that in certain places in the code, the field name was being used to access the dataframe rather than using the mapped column name from the column mapping.

In addition I found that the enumerator type information in the enumerators csv was not being validated. I have added a validation check for this.

## How Has This Been Tested?

This error was not caught previously because the test csv's had columns that all matched the field names. I have updated some of the test csv's to have different column names (like `target_id1` instead of `target_id`).

## To-do before merge

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have updated the automated tests (if applicable)
- [x] I have updated the README file (if applicable)
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/

[DDSSPB-47]: https://idinsight.atlassian.net/browse/DDSSPB-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ