### PR TITLE
[DODSSPB-41] Remove unused column constraint on enumerators

### DIFF
--- a/app/blueprints/enumerators/utils.py
+++ b/app/blueprints/enumerators/utils.py
@@ -193,13 +193,6 @@ class EnumeratorsUpload:
                     f"Column name '{column_name}' from the column mapping appears {file_columns.count(column_name)} time(s) in the uploaded file. It should appear exactly once."
                 )
 
-        # Each column in the csv file should be mapped exactly once
-        for column_name in file_columns:
-            if expected_columns.count(column_name) != 1:
-                file_structure_errors.append(
-                    f"Column name '{column_name}' in the csv file appears {expected_columns.count(column_name)} time(s) in the column mapping. It should appear exactly once."
-                )
-
         if len(file_structure_errors) > 0:
             raise InvalidFileStructureError(file_structure_errors)
 


### PR DESCRIPTION
# [DODSSPB-41] Remove unused column constraint on enumerators

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DODSSPB-41

## Description, Motivation and Context

This PR was meant to fix a bug where users were not allowed to have unmapped columns in the csv file. The fix was implemented for targets but not for enumerators. This PR makes the fix for enumerators as well.

## How Has This Been Tested?

Tests are passing.

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [x] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [x] I have updated the automated tests (if applicable)
- [x] I have updated the README file (if applicable)
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
