### PR TITLE
SCTO form variables fix

### DIFF
--- a/app/blueprints/forms/controllers.py
+++ b/app/blueprints/forms/controllers.py
@@ -433,6 +433,7 @@ def ingest_scto_form_definition(form_uid):
         )
 
         public_key = settings_dict.get("public_key", None)
+        submission_url = settings_dict.get("submission_url", None)
 
         # return jsonify(settings_dict), 422
         scto_settings = SCTOFormSettings(
@@ -440,7 +441,7 @@ def ingest_scto_form_definition(form_uid):
             form_title=settings_dict["form_title"],
             version=scto_form_version,
             public_key=public_key,
-            submission_url=settings_dict["submission_url"],
+            submission_url=submission_url,
             default_language=settings_dict["default_language"],
         )
 


### PR DESCRIPTION
# [DDSSPB-39] <SCTO form variables fix> SCTO form variables fix

This PR addresses the issue of the "public_key not found" error when fetching SCTO form variables. It resolves the problem by employing a get command to verify the presence of the field before its utilisation.

## Ticket

Fixes: https://idinsight.atlassian.net/browse/DDSSPB-39

## Description, Motivation and Context

- use a get command to fetch `public_key` default to `None` if not found

## How Has This Been Tested?
- local dev

## Checklist:

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have written [good commit messages][1]


[DDSSPB-39]: https://idinsight.atlassian.net/browse/DDSSPB-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ