### PR TITLE
[SS-1461] Fix issue in default table config

### DIFF
--- a/app/blueprints/assignments/table_config/default_config.py
+++ b/app/blueprints/assignments/table_config/default_config.py
@@ -171,7 +171,7 @@ class DefaultTableConfig:
                 "group_label": None,
                 "columns": [
                     {
-                        "column_key": "assigned_enumerator_name",
+                        "column_key": "name",
                         "column_label": "Surveyor Name",
                     },
                 ],

--- a/tests/unit/test_assignments.py
+++ b/tests/unit/test_assignments.py
@@ -2944,7 +2944,7 @@ class TestAssignments:
                 {
                     "columns": [
                         {
-                            "column_key": "assigned_enumerator_name",
+                            "column_key": "name",
                             "column_label": "Surveyor Name",
                         }
                     ],
@@ -3305,7 +3305,7 @@ class TestAssignments:
                 {
                     "columns": [
                         {
-                            "column_key": "assigned_enumerator_name",
+                            "column_key": "name",
                             "column_label": "Surveyor Name",
                         }
                     ],
@@ -3616,7 +3616,7 @@ class TestAssignments:
                 {
                     "columns": [
                         {
-                            "column_key": "assigned_enumerator_name",
+                            "column_key": "name",
                             "column_label": "Surveyor Name",
                         }
                     ],


### PR DESCRIPTION
# [SS-1461] Fix issue in default table config

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1461

## Description, Motivation and Context

This PR fixes an issue in the default table config raised by @Jayprakash-SE. The assignments_surveyors config was using the `assigned_enumerator_name` access key when it should have been using the `name` key.

## How Has This Been Tested?

Tests have been updated and are passing.

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [x] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [x] I have updated the automated tests (if applicable)
- [x] I have updated the README file (if applicable)
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[SS-1461]: https://idinsight.atlassian.net/browse/SS-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ