### PR TITLE
Update permission checking to work with enumerator_uid

### DIFF
--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -155,9 +155,9 @@ def get_survey_uids(param_location, param_name):
     from app.blueprints.targets.models import Target
     from app.blueprints.enumerators.models import SurveyorForm, MonitorForm
 
-    if param_name not in ["survey_uid", "form_uid", "target_uid"]:
+    if param_name not in ["survey_uid", "form_uid", "target_uid", "enumerator_uid"]:
         raise ValueError(
-            "'param_name' parameter must be one of survey_uid, form_uid, target_uid"
+            "'param_name' parameter must be one of survey_uid, form_uid, target_uid, enumerator_uid"
         )
     if param_location not in ["query", "path", "body"]:
         raise ValueError("'param_location' parameter must be one of query, path, body")
@@ -235,7 +235,7 @@ def custom_permissions_required(
     permission_name, survey_uid_param_location=None, survey_uid_param_name=None
 ):
     """
-    Function to check if current user has the required permissions
+    Function to check if the current user has the required permissions
     """
     from app.blueprints.roles.models import Permission, Role, SurveyAdmins
 


### PR DESCRIPTION
# Update permission checking to work with enumerator_uid

## Description, Motivation and Context

For permission checking we ran into an issue with inferring the survey_uid using enumerator_uid as an input. Because the main `enumerators` model is independent of any form or survey, we decided to check for all the surveys where that enumerator is working and allow access if the user has the required permissions on any of those surveys.

The implementation involves returning a list from the `get_survey_uids()` function rather than returning an integer from the previous `get_survey_uid()` function.

## How Has This Been Tested?

Tests are passing.

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [x] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [x] I have updated the automated tests (if applicable)
- [x] I have updated the README file (if applicable)
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
