### PR TITLE
[SS-1515] - Set target_assignable to True when None (new targets)

### DIFF
--- a/app/blueprints/assignments/controllers.py
+++ b/app/blueprints/assignments/controllers.py
@@ -159,7 +159,7 @@ def view_assignments(validated_query_params):
                             target_status, "last_attempt_survey_status_label", None
                         ),
                         "target_assignable": getattr(
-                            target_status, "target_assignable", None
+                            target_status, "target_assignable", True # If the target_status is None, the target is new and hence, assignable
                         ),
                         "webapp_tag_color": getattr(
                             target_status, "webapp_tag_color", None
@@ -307,7 +307,7 @@ def update_assignments(validated_payload):
         elif (
             len(target_result) == 2
             and target_result[1] is not None
-            and target_result[1].target_assignable is not True
+            and getattr(target_result[1], "target_assignable", True) is not True
         ):
             unassignable_target_uids.append(assignment["target_uid"])
 

--- a/tests/unit/test_assignments.py
+++ b/tests/unit/test_assignments.py
@@ -1321,7 +1321,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "1",
                     "target_locations": [
                         {
@@ -1391,7 +1391,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "2",
                     "target_locations": [
                         {
@@ -1521,7 +1521,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "1",
                     "target_locations": [
                         {
@@ -1588,7 +1588,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "2",
                     "target_locations": [
                         {
@@ -1729,7 +1729,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "1",
                     "target_locations": [
                         {
@@ -1796,7 +1796,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "2",
                     "target_locations": [
                         {
@@ -1957,7 +1957,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "1",
                     "target_locations": [
                         {
@@ -2024,7 +2024,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "2",
                     "target_locations": [
                         {
@@ -2219,7 +2219,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "1",
                     "target_locations": None,
                     "target_uid": 1,
@@ -2263,7 +2263,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "2",
                     "target_locations": None,
                     "target_uid": 2,
@@ -2374,7 +2374,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "1",
                     "target_locations": [
                         {
@@ -2462,7 +2462,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "2",
                     "target_locations": [
                         {
@@ -2613,7 +2613,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "1",
                     "target_locations": [
                         {
@@ -2680,7 +2680,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "2",
                     "target_locations": [
                         {
@@ -2831,7 +2831,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "1",
                     "target_locations": [
                         {
@@ -2919,7 +2919,7 @@ class TestAssignments:
                     "num_attempts": None,
                     "refusal_flag": None,
                     "revisit_sections": None,
-                    "target_assignable": None,
+                    "target_assignable": True,
                     "target_id": "2",
                     "target_locations": [
                         {


### PR DESCRIPTION
# [SS-1515] - Set target_assignable to True when None (new targets)

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1515

## Description, Motivation and Context

If there are new targets added to the targets screen, the corresponding target status is not available in the `target_status` table till the next pipeline run completes. We want to allow assignments for these new targets. This PR updates the `assignments` endpoint to return `true` in `target_assignable` when None. 

## How Has This Been Tested?
Unit tests have been updated with the same changes and they pass

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
~~- [ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)~~
~~- [ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.~~
- [x] I have updated the automated tests (if applicable)
~~- [ ] I have updated the README file (if applicable)~~
~~- [ ] I have updated the OpenAPI documentation (if applicable)~~

[1]: http://chris.beams.io/posts/git-commit/


[SS-1515]: https://idinsight.atlassian.net/browse/SS-1515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ