### PR TITLE
[Minor] - Check enumerator is present before loading surveyor stats

### DIFF
--- a/app/blueprints/enumerators/controllers.py
+++ b/app/blueprints/enumerators/controllers.py
@@ -1418,14 +1418,15 @@ def update_surveyor_stats(validated_payload):
             Enumerator.enumerator_id == enumerator_id,
         ).first()
 
-        db.session.add(
-            SurveyorStats(
-                form_uid=form_uid,
-                enumerator_uid=enumerator.enumerator_uid,
-                avg_num_submissions_per_day=surveyor["avg_num_submissions_per_day"],
-                avg_num_completed_per_day=surveyor["avg_num_completed_per_day"],
+        if enumerator is not None:
+            db.session.add(
+                SurveyorStats(
+                    form_uid=form_uid,
+                    enumerator_uid=enumerator.enumerator_uid,
+                    avg_num_submissions_per_day=surveyor["avg_num_submissions_per_day"],
+                    avg_num_completed_per_day=surveyor["avg_num_completed_per_day"],
+                )
             )
-        )
 
     try:
         db.session.commit()


### PR DESCRIPTION
# [Minor] - Check enumerator is present before loading surveyor stats

## Ticket

Not created

## Description, Motivation and Context

This is a minor fix added to the `surveyor-stats` PUT endpoint to check if enumerator is available. The `surveyor-stats` table is loaded using SurveyCTO data. It is possible that the Enumerator ID recorded on SurveyCTO doesn't match Callisto. While in some cases this could indicate enumerator list on Callisto is not up to date and requires action from project team, sometimes it could also be a data issue. To prevent raising error and stopping all subsequent steps, this fix ensures that `surveyor-stats` is loaded with stats for all enumerators in Callisto. Others enumerators are skipped till the underlying cause (SurveyCTO data error, adding new enumerators to Callisto etc.) is fixed. 

## How Has This Been Tested?
On local

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
~~- [ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)~~
~~- [ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.~~
~~- [ ] I have updated the automated tests (if applicable)~~
~~- [ ] I have updated the README file (if applicable)~~
~~- [ ] I have updated the OpenAPI documentation (if applicable)~~

[1]: http://chris.beams.io/posts/git-commit/
