### PR TITLE
[SS-1517] Remove SurveyorLocation filter from assignment enum

### DIFF
--- a/app/blueprints/assignments/controllers.py
+++ b/app/blueprints/assignments/controllers.py
@@ -234,7 +234,6 @@ def view_assignments_enumerators(validated_query_params):
         .filter(
             SurveyorForm.form_uid == form_uid,
             SurveyorForm.status.in_(["Active", "Temp. Inactive"]),
-            SurveyorLocation.form_uid == form_uid,
         )
     )
 


### PR DESCRIPTION
# [SS-1517] Remove SurveyorLocation filter from assignment enum

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1517

## Description, Motivation and Context
Remove `SurveyorLocation` filter from assignment enumerators query

## How Has This Been Tested?
Yes, locally.


## Checklist:
- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[1]: http://chris.beams.io/posts/git-commit/


[SS-1517]: https://idinsight.atlassian.net/browse/SS-1517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ