### PR TITLE
[BUGFIX] Dockerfile : Add curl for Airflow E2E tests

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -9,7 +9,7 @@ ARG NAME
 ARG PORT
 ARG HOME_DIR=/usr/src/${NAME}
 
-RUN apt-get update && apt-get -y install libpq-dev gcc jq wget
+RUN apt-get update && apt-get -y install libpq-dev gcc jq wget curl
 
 ENV DOCKERIZE_VERSION v0.7.0
 


### PR DESCRIPTION
# [BUGFIX] Dockerfile: Add curl for Airflow E2E tests

## Ticket

Fixes: No ticket created

## Description, Motivation and Context

Airflow E2E Tests were failing, with flask container returning unhealthy on tests. [Test log](https://github.com/IDinsight/surveystream_airflow_pipeline/actions/runs/8187323164/job/22387550254?pr=563)
Curl is used for a health check on the flask API container on airflow e2e test.

Changes include:

- Install Curl in Dockerfile.api 

Reference: https://github.com/IDinsight/surveystream_flask_api/pull/91

## How Has This Been Tested?

Running Airflow E2E Tests on local and [Github actions](https://github.com/IDinsight/surveystream_airflow_pipeline/actions/runs/8189652143/job/22394870836?pr=564)

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
