### PR TITLE
added an new step to dev pipeline

### DIFF
--- a/.github/workflows/cicd_unittest_deploy.yml
+++ b/.github/workflows/cicd_unittest_deploy.yml
@@ -132,6 +132,18 @@ jobs:
             echo "DB is not up to date";\
             exit 1;\
           fi
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-post-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: web-callisto-ecr-repository
+          IMAGE_TAG: PostMigration
+
+        run: |
+          docker build -f Dockerfile.api --rm --build-arg NAME=${{ env.BACKEND_NAME }} --build-arg PORT=${{ env.BACKEND_PORT }} --platform=linux/amd64 -t ${{ env.BACKEND_NAME }}:${{ env.VERSION }} .
+          docker tag ${{ env.BACKEND_NAME }}:${{ env.VERSION }} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   Deploy-Staging:
     if: github.event_name == 'push' &&  github.ref == 'refs/heads/staging'


### PR DESCRIPTION
# [SS-1532]  Feature: Add Build and Push step on Callisto Dev CI/CD Pipeline


## Ticket

Feature: https://idinsight.atlassian.net/browse/SS-1532

## Description, Motivation and Context
The goal of the task is to have an Image for Dev that can be used by airflow during e2e tests. Currently, the tests have to clone the dev branch and build the image which is taking long. The current image, `PreMigration` could have been used however should the pipeline fail, they will be using an image that has migration issues. Therefore the new step will fix the issue.

## How Has This Been Tested?
Locally, an image from the `web-callisto-ecr-repository` can be used for the e2e tests. This has not been tested on the Airflow github action

## Checklist:

- [ ] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have written [good commit messages][1]
- [ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[SS-1532]: https://idinsight.atlassian.net/browse/SS-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ