### PR TITLE
[SS-1557] Remove dockerize

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -11,10 +11,6 @@ ARG HOME_DIR=/usr/src/${NAME}
 
 RUN apt-get update && apt-get -y install libpq-dev gcc jq wget curl
 
-ENV DOCKERIZE_VERSION v0.7.0
-
-RUN wget -O - https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xzf - -C /usr/local/bin
-
 ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
 RUN /install.sh && rm /install.sh
 

--- a/docker-compose/docker-compose.unit-test.yml
+++ b/docker-compose/docker-compose.unit-test.yml
@@ -13,6 +13,11 @@ services:
       - "5433:5433"
     command:
       -p 5433
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -p 5433"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   api:
     image: ${BACKEND_NAME}:${VERSION}
     environment:
@@ -24,14 +29,14 @@ services:
     volumes:
       - /tmp/coverage:/usr/src/${BACKEND_NAME}/tests/output
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
     entrypoint: ["/bin/bash","-c"]
     command:
     - |
        . /bootstrap.sh
-       dockerize -wait tcp://postgres:5433 -timeout 15m -wait-retry-interval 10s 
        coverage run -m pytest tests -vv
        coverage lcov --include="/usr/src/${BACKEND_NAME}/app/*" -o /usr/src/${BACKEND_NAME}/tests/output/coverage.lcov
        


### PR DESCRIPTION
# [SS-1557] Remove dockerize

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1557

## Description, Motivation and Context

In the unit test docker-compose file we are using the `dockerize` package to wait for the db container to spin up. However, there is a native way to achieve the same functionality with the `healthcheck` directive in docker compose. I had implemented this on AAM and wanted to quickly add it here on SurveyStream as well.

## How Has This Been Tested?

Tests are passing

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [x] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [x] I have updated the automated tests (if applicable)
- [x] I have updated the README file (if applicable)
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[SS-1557]: https://idinsight.atlassian.net/browse/SS-1557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ