### PR TITLE
[SS-1560] Update Sentry environment name

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -202,7 +202,7 @@ class ProductionConfig(Config):
     SENTRY_CONFIG = {
         "dsn": "https://c320e08cbf204069afb2cc62ee498018@o564222.ingest.sentry.io/4505070237319168",
         "traces_sample_rate": "1.0",
-        "environment": "production",
+        "environment": "production-callisto",
     }
 
     ORIGINS = ["https://*.idinsight.io"]


### PR DESCRIPTION
# [SS-1560] Update Sentry environment name

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1560

## Description, Motivation and Context

Web app v1 and v2 are using overlapping environment names in the Sentry configuration. This makes it hard to use Sentry to diagnose and fix issues. This PR updates the Sentry config so that Callisto is using its own unique environment names.

I will raise a similar PR for the front end.

## How Has This Been Tested?

Not relevant for this change

## Checklist:

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [x] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [x] I have updated the automated tests (if applicable)
- [x] I have updated the README file (if applicable)
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[SS-1560]: https://idinsight.atlassian.net/browse/SS-1560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ