### PR TITLE
[Minor] - Update staging url on flask

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -172,7 +172,7 @@ class StagingConfig(Config):
         Config.DB_NAME,
     )
 
-    REACT_BASE_URL = "https://callisto.stg.surveystream.idinsight.io"
+    REACT_BASE_URL = "https://stg.surveystream.idinsight.io"
 
     SENTRY_CONFIG = {
         "dsn": "https://c320e08cbf204069afb2cc62ee498018@o564222.ingest.sentry.io/4505070237319168",


### PR DESCRIPTION
# [Minor] - Update staging url

## Ticket

Not created

## Description, Motivation and Context

Since staging was moved to https://stg.surveystream.idinsight.io, making required change on config file.
Haven't changed the sentry environment value which is currently "staging-callisto"

## How Has This Been Tested?
Not tested

## To-do before merge
None
