### PR TITLE
[SS-1589, Minor] - Added option to recreate volumes on container up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,8 @@ container-down:
 	VERSION=${VERSION} \
 	ADMIN_ACCOUNT=${ADMIN_ACCOUNT} \
 	docker-compose -f docker-compose/docker-compose.remote-dev-db.yml -f docker-compose/docker-compose.override.yml down -v
-
+	@docker system prune --volumes -f
+	
 run-unit-tests:
 	@BACKEND_NAME=${BACKEND_NAME} \
 	VERSION=${VERSION} \


### PR DESCRIPTION
# [SS-1589, Minor] - Added option to recreate volumes on container up

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1589

## Description, Motivation and Context

Addressing comment on [the PR](https://github.com/IDinsight/surveystream_flask_api/pull/144), the option:
- `--force-recreate` - recreates containers whenever the `make container-up` command is called
- `-V` - recreates volumes instead of reusing volumes

Also adding a docker system prune command in `make container-down` to ensure all dangling volumes detached from container (due to running `make container-up` without killing containers) are removed. 

## How Has This Been Tested?
On local

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[1]: http://chris.beams.io/posts/git-commit/
