### PR TITLE
[Minor, SS-1818] - Fix duplicate value in TKPI community form questions

### DIFF
--- a/app/blueprints/forms/controllers.py
+++ b/app/blueprints/forms/controllers.py
@@ -522,6 +522,11 @@ def ingest_scto_form_definition(form_uid):
     # Loop through the rows of the `survey` tab of the form definition
     for row in scto_form_definition["fieldsRowsAndColumns"][1:]:
         questions_dict = dict(zip(survey_tab_columns, row))
+
+        # Skip questions with disabled = Yes
+        if questions_dict.get("disabled", "No").strip().lower() == "yes":
+            continue
+
         if questions_dict["name"].strip() != "":
             # There can be nested repeat groups, so we need to keep track of the depth in order to determine if a question is part of a repeat group
             repeat_group_depth = 0


### PR DESCRIPTION
# [Minor, SS-1818] - Fix duplicate value in TKPI community form questions

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1818

## Description, Motivation and Context

As per investigation, we found that the reason for duplicate question names in the TKPI community form was because if a question has `disabled` = `yes`, SurveyCTO ignores these fields and excludes it from the duplicate check. To remove these duplicates from our data, we are adding a filter on this column. 
We want to remove the fields with `disabled = yes` from our data because 1) duplicates in the drop down menu causes errors on the UI and 2) since these fields are ignored by SurveCTO and not in the extracted data, they should not be used in SurveyStream as well.

## How Has This Been Tested?
On local using unit tests and loading the TKPI form questions on dev

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- ~~[ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)~~
- ~~[ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.~~
- ~~[ ] I have updated the automated tests (if applicable)~~
- ~~[ ] I have updated the README file (if applicable)~~
- ~~[ ] I have updated the OpenAPI documentation (if applicable)~~

[1]: http://chris.beams.io/posts/git-commit/
