### PR TITLE
Bugfix: Add query param validator to `/api/users` endpoint

### DIFF
--- a/app/blueprints/user_management/controllers.py
+++ b/app/blueprints/user_management/controllers.py
@@ -18,11 +18,13 @@ from .validators import (
     WelcomeUserValidator,
     EditUserValidator,
     CheckUserValidator,
+    GetUsersQueryParamValidator,
 )
 from app.utils.utils import (
     custom_permissions_required,
     logged_in_active_user_required,
     validate_payload,
+    validate_query_params,
 )
 
 
@@ -335,13 +337,15 @@ def get_user(user_uid):
 
 @user_management_bp.route("/users", methods=["GET"])
 @logged_in_active_user_required
+@validate_query_params(GetUsersQueryParamValidator)
 @custom_permissions_required("ADMIN", "query", "survey_uid")
-def get_all_users():
+def get_all_users(validated_query_params):
     """
     Endpoint to get information for all users.
     """
 
-    survey_uid = request.args.get("survey_uid")
+    survey_uid = validated_query_params.survey_uid.data
+
     if survey_uid is None and not current_user.is_super_admin:
         return jsonify(message="Survey UID is required for non-super-admin users"), 400
 

--- a/app/blueprints/user_management/validators.py
+++ b/app/blueprints/user_management/validators.py
@@ -10,6 +10,13 @@ from wtforms import (
 from wtforms.validators import DataRequired, Email, Optional, ValidationError
 
 
+class GetUsersQueryParamValidator(FlaskForm):
+    class Meta:
+        csrf = False
+
+    survey_uid = IntegerField()
+
+
 class RegisterValidator(FlaskForm):
     email = StringField("Email", validators=[DataRequired()])
     password = PasswordField("Password", validators=[DataRequired()])

--- a/tests/unit/test_user_management.py
+++ b/tests/unit/test_user_management.py
@@ -223,10 +223,80 @@ class TestUserManagement:
 
         assert response.status_code == 200
 
-        # Check if the returned data is a list of users
-        users = json.loads(response.data)
+        print(response.json)
 
-        assert isinstance(users, list)
+        expected_response = [
+            {
+                "can_create_survey": None,
+                "email": "surveystream.devs@idinsight.org",
+                "first_name": None,
+                "is_super_admin": True,
+                "last_name": None,
+                "roles": None,
+                "status": "Active",
+                "user_admin_survey_names": [],
+                "user_admin_surveys": [],
+                "user_role_names": [None],
+                "user_survey_names": [None],
+                "user_uid": 1,
+            },
+            {
+                "can_create_survey": None,
+                "email": "registration_user",
+                "first_name": None,
+                "is_super_admin": True,
+                "last_name": None,
+                "roles": None,
+                "status": "Active",
+                "user_admin_survey_names": [],
+                "user_admin_surveys": [],
+                "user_role_names": [None],
+                "user_survey_names": [None],
+                "user_uid": 2,
+            },
+        ]
+
+        checkdiff = jsondiff.diff(expected_response, response.json)
+
+        assert checkdiff == {}
+
+    def test_get_all_users_by_survey(self, client, login_test_user, csrf_token):
+        """
+        Test endpoint for getting all users for a survey
+        Expect a user list
+        """
+        response = client.get(
+            "/api/users",
+            headers={"X-CSRF-Token": csrf_token},
+            query_string={"survey_uid": 1},
+        )
+
+        assert response.status_code == 200
+
+        assert response.json == []
+
+    def test_get_all_users_invalid_param(self, client, login_test_user, csrf_token):
+        """
+        Test endpoint for getting all users
+        Test that an invalid parameter returns the correct error
+        Expect a user list
+        """
+        response = client.get(
+            "/api/users",
+            headers={"X-CSRF-Token": csrf_token},
+            query_string={"survey_uid": "undefined"},
+        )
+
+        assert response.status_code == 400
+
+        expected_response = {
+            "data": None,
+            "message": {"survey_uid": ["Not a valid integer value."]},
+            "success": False,
+        }
+
+        checkdiff = jsondiff.diff(expected_response, response.json)
+        assert checkdiff == {}
 
     def test_deactivate_user(self, client, login_test_user, csrf_token, sample_user):
         """


### PR DESCRIPTION
Bugfix: Add query param validator to `/api/users` endpoint

## Description, Motivation and Context

This PR addresses [this Sentry issue](https://idinsight.sentry.io/issues/5646731781/?referrer=slack&notification_uuid=46cf5723-c721-41e5-976c-2f4c13d09a81&alert_rule_id=14186375&alert_type=issue).

The front end is passing an invalid query parameter `survey_uid='undefined'` to the back end. This endpoint is missing a query param validator so this is leading to an uncaught exception on the back end.

This PR adds the query param validator to the endpoint. However, the underlying problem on the front end that is leading to the invalid query param still needs to be addressed by @Jayprakash-SE.

## How Has This Been Tested?

New test cases are passing

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [x] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [x] I have updated the automated tests (if applicable)
- [x] I have updated the README file (if applicable)
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
