### PR TITLE
[SS-1925] Fix NotNullViolation on Email template

### DIFF
--- a/app/blueprints/emails/controllers.py
+++ b/app/blueprints/emails/controllers.py
@@ -1184,6 +1184,8 @@ def update_email_template(email_template_uid, validated_payload):
                 variable_name=table.get("variable_name"),
             )
             db.session.add(table_obj)
+            db.session.flush()
+
             table_uid = table_obj.email_template_table_uid
             # Get the max filter group id
             max_filter_group_id = 0


### PR DESCRIPTION
# [SS-1925] Fix NotNullViolation on Email template

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1925

## Description, Motivation and Context
`db.session.flush()` will generate the `email_template_table_uid` for `table_obj`.

## How Has This Been Tested?
Locally

## Checklist:
- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]

[1]: http://chris.beams.io/posts/git-commit/


[SS-1925]: https://idinsight.atlassian.net/browse/SS-1925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ