### PR TITLE
[SS-1928] Add user_name in user-location and user-language API

### DIFF
--- a/app/blueprints/docs/surveystream.yml
+++ b/app/blueprints/docs/surveystream.yml
@@ -1094,6 +1094,9 @@ paths:
                         user_uid:
                           type: integer
                           description: The unique ID of the user
+                        user_name:
+                          type: string
+                          description: The name of the user
                         location_uid:
                           type: integer
                           description: The unique ID of the location
@@ -1245,6 +1248,9 @@ paths:
                         user_uid:
                           type: integer
                           description: The unique ID of the user
+                        user_name:
+                          type: string
+                          description: The name of the user
                         language:
                           type: string
                           description: The language of the user

--- a/app/blueprints/user_management/controllers.py
+++ b/app/blueprints/user_management/controllers.py
@@ -819,10 +819,14 @@ def get_user_locations(validated_query_params):
     user_location_query = (
         db.session.query(
             UserLocation.user_uid,
+            func.concat(
+                User.first_name, ' ', User.last_name
+            ).label('user_name'),
             UserLocation.location_uid,
             Location.location_id,
             Location.location_name,
         )
+        .join(User, User.user_uid == UserLocation.user_uid)
         .join(
             Location,
             (Location.location_uid == UserLocation.location_uid)
@@ -846,11 +850,12 @@ def get_user_locations(validated_query_params):
                     "data": [
                         {
                             "user_uid": user_uid,
+                            "user_name": user_name,
                             "location_uid": location_uid,
                             "location_id": location_id,
                             "location_name": location_name,
                         }
-                        for user_uid, location_uid, location_id, location_name in user_locations
+                        for user_uid, user_name, location_uid, location_id, location_name in user_locations
                     ],
                 }
             ),
@@ -926,10 +931,17 @@ def get_user_languages(validated_query_params):
     survey_uid = validated_query_params.survey_uid.data
     user_uid = validated_query_params.user_uid.data
 
-    user_language_query = db.session.query(
-        UserLanguage.user_uid,
-        UserLanguage.language,
-    ).filter(UserLanguage.survey_uid == survey_uid)
+    user_language_query = (
+        db.session.query(
+            UserLanguage.user_uid,
+            func.concat(
+                User.first_name, ' ', User.last_name
+            ).label('user_name'),
+            UserLanguage.language,
+        )
+        .join(User, User.user_uid == UserLanguage.user_uid)
+        .filter(UserLanguage.survey_uid == survey_uid)
+    )
 
     if user_uid:
         user_language_query = user_language_query.filter(
@@ -946,9 +958,10 @@ def get_user_languages(validated_query_params):
                     "data": [
                         {
                             "user_uid": user_uid,
+                            "user_name": user_name,
                             "language": language,
                         }
-                        for user_uid, language in user_languages
+                        for user_uid, user_name, language in user_languages
                     ],
                 }
             ),

--- a/tests/unit/test_user_management.py
+++ b/tests/unit/test_user_management.py
@@ -913,6 +913,7 @@ class TestUserManagement:
                 {
                     "location_uid": 1,
                     "user_uid": 3,
+                    "user_name": "John Doe2",
                     "location_id": "1",
                     "location_name": "ADILABAD",
                 }
@@ -1029,6 +1030,7 @@ class TestUserManagement:
                 {
                     "location_uid": 1,
                     "user_uid": user_uid,
+                    "user_name": "Updated User",
                     "location_id": "1",
                     "location_name": "ADILABAD",
                 }
@@ -1066,6 +1068,7 @@ class TestUserManagement:
                 {
                     "location_uid": 1,
                     "user_uid": user_uid,
+                    "user_name": "Updated User",
                     "location_id": "1",
                     "location_name": "ADILABAD",
                 }
@@ -1103,6 +1106,7 @@ class TestUserManagement:
                 {
                     "location_uid": 1,
                     "user_uid": user_uid,
+                    "user_name": "Updated User",
                     "location_id": "1",
                     "location_name": "ADILABAD",
                 }
@@ -1149,6 +1153,7 @@ class TestUserManagement:
                 {
                     "location_uid": 1,
                     "user_uid": user_uid,
+                    "user_name": "Updated User",
                     "location_id": "1",
                     "location_name": "ADILABAD",
                 },
@@ -1201,6 +1206,7 @@ class TestUserManagement:
                 {
                     "location_uid": 1,
                     "user_uid": user_uid,
+                    "user_name": "Updated User",
                     "location_id": "1",
                     "location_name": "ADILABAD",
                 },
@@ -1401,8 +1407,8 @@ class TestUserManagement:
 
         expected_response = {
             "data": [
-                {"language": "English", "user_uid": user_uid},
-                {"language": "Hindi", "user_uid": user_uid},
+                {"language": "English", "user_uid": user_uid, "user_name": "Updated User"},
+                {"language": "Hindi", "user_uid": user_uid, "user_name": "Updated User"},
             ],
             "success": True,
         }
@@ -1434,8 +1440,8 @@ class TestUserManagement:
 
         expected_response = {
             "data": [
-                {"language": "English", "user_uid": user_uid},
-                {"language": "Hindi", "user_uid": user_uid},
+                {"language": "English", "user_uid": user_uid, "user_name": "Updated User"},
+                {"language": "Hindi", "user_uid": user_uid, "user_name": "Updated User"},
             ],
             "success": True,
         }


### PR DESCRIPTION
# [SS-1928] Add user_name in user-location and user-language API

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1928

## Description, Motivation and Context
Generic mapping is required to show the user name so adding the user name in user-location and user-language API endpoint.

## How Has This Been Tested?
Locally

## Checklist:
- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have updated the automated tests (if applicable)
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[SS-1928]: https://idinsight.atlassian.net/browse/SS-1928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ