### PR TITLE
[SS-1929] - Adding endpoint to fetch lowest level supervisors with gender

### DIFF
--- a/app/blueprints/docs/surveystream.yml
+++ b/app/blueprints/docs/surveystream.yml
@@ -1064,7 +1064,7 @@ paths:
     get:
       tags:
         - User Management
-      summary: Get user location details
+      summary: Get user location details for users with the lowest field supervisor role
       description: Get user location details for a survey and for a specific user if user_uid is provided
       parameters:
         - in: query
@@ -1218,7 +1218,7 @@ paths:
     get:
       tags:
         - User Management
-      summary: Get user languages
+      summary: Get user languages for users with the lowest field supervisor role
       description: Get user languages for a survey and for a specific user if user_uid is provided
       parameters:
         - in: query
@@ -1263,6 +1263,66 @@ paths:
                 properties:
                   message:
                     type: string        
+  
+  "/user-gender":
+    get:
+      tags:
+        - User Management
+      summary: Get user gender for users with the lowest field supervisor role
+      description: Get user gender for a survey and for a specific user if user_uid is provided for users with the lowest field supervisor role
+      parameters:
+        - in: query
+          name: survey_uid
+          schema:
+            type: string
+          required: true
+        - in: query
+          name: user_uid
+          schema:
+            type: string
+      responses:
+        "200":
+          description: User gender retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: list
+                    items:
+                      type: object
+                      properties:
+                        user_uid:
+                          type: integer
+                          description: The unique ID of the user
+                        user_name:
+                          type: string
+                          description: The name of the user
+                        gender:
+                          type: string
+                          description: Gender of the user
+        "404":
+          description: User gender data not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        "422":
+          description: Role hierarchy errors
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+  
   /surveys:
     get:
       summary: Get surveys

--- a/app/blueprints/user_management/controllers.py
+++ b/app/blueprints/user_management/controllers.py
@@ -2,15 +2,16 @@ from flask import current_app, jsonify, request
 from flask_login import current_user
 from flask_mail import Message
 from passlib.pwd import genword
-from sqlalchemy import case, distinct, func, or_, null, case
+from sqlalchemy import case, distinct, func, null, or_
 from sqlalchemy.exc import IntegrityError
 
 from app import db, mail
 from app.blueprints.auth.models import ResetPasswordToken, User
 from app.blueprints.forms.models import Form
-
-from app.blueprints.roles.models import Role, SurveyAdmin, UserHierarchy
 from app.blueprints.locations.models import Location
+from app.blueprints.roles.errors import InvalidRoleHierarchyError
+from app.blueprints.roles.models import Role, SurveyAdmin, UserHierarchy
+from app.blueprints.roles.utils import RoleHierarchy
 from app.blueprints.surveys.models import Survey
 from app.utils.utils import (
     custom_permissions_required,
@@ -27,10 +28,11 @@ from .validators import (
     CheckUserValidator,
     CompleteRegistrationValidator,
     EditUserValidator,
+    GetUserGenderParamValidator,
+    GetUserLanguagesParamValidator,
+    GetUserLocationsParamValidator,
     GetUsersQueryParamValidator,
     RegisterValidator,
-    GetUserLocationsParamValidator,
-    GetUserLanguagesParamValidator,
     UserLocationsParamValidator,
     UserLocationsPayloadValidator,
     WelcomeUserValidator,
@@ -819,9 +821,7 @@ def get_user_locations(validated_query_params):
     user_location_query = (
         db.session.query(
             UserLocation.user_uid,
-            func.concat(
-                User.first_name, ' ', User.last_name
-            ).label('user_name'),
+            func.concat(User.first_name, " ", User.last_name).label("user_name"),
             UserLocation.location_uid,
             Location.location_id,
             Location.location_name,
@@ -832,6 +832,7 @@ def get_user_locations(validated_query_params):
             (Location.location_uid == UserLocation.location_uid)
             & (Location.survey_uid == survey_uid),
         )
+        .filter(User.active.is_(True))
         .filter(UserLocation.survey_uid == survey_uid)
     )
 
@@ -934,12 +935,11 @@ def get_user_languages(validated_query_params):
     user_language_query = (
         db.session.query(
             UserLanguage.user_uid,
-            func.concat(
-                User.first_name, ' ', User.last_name
-            ).label('user_name'),
+            func.concat(User.first_name, " ", User.last_name).label("user_name"),
             UserLanguage.language,
         )
         .join(User, User.user_uid == UserLanguage.user_uid)
+        .filter(User.active.is_(True))
         .filter(UserLanguage.survey_uid == survey_uid)
     )
 
@@ -969,3 +969,59 @@ def get_user_languages(validated_query_params):
         )
     else:
         return jsonify(message="User languages not found"), 404
+
+
+# User Gender
+@user_management_bp.route("/user-gender", methods=["GET"])
+@logged_in_active_user_required
+@validate_query_params(GetUserGenderParamValidator)
+def get_user_gender(validated_query_params):
+    """Function to get users with the bottom level role in a survey along with gender"""
+
+    survey_uid = validated_query_params.survey_uid.data
+    user_uid = validated_query_params.user_uid.data
+
+    roles = [
+        role.to_dict() for role in Role.query.filter_by(survey_uid=survey_uid).all()
+    ]
+
+    try:
+        roles = RoleHierarchy(roles)
+    except InvalidRoleHierarchyError as e:
+        return (
+            jsonify({"success": False, "errors": e.role_hierarchy_errors}),
+            422,
+        )
+
+    bottom_level_role_uid = roles.ordered_roles[-1]["role_uid"]
+
+    user_gender_query = db.session.query(
+        User.user_uid,
+        func.concat(User.first_name, " ", User.last_name).label("user_name"),
+        User.gender,
+    ).filter(User.active.is_(True), User.roles.any(bottom_level_role_uid))
+
+    if user_uid:
+        user_gender_query = user_gender_query.filter(User.user_uid == user_uid)
+
+    user_gender = user_gender_query.all()
+
+    if user_gender:
+        return (
+            jsonify(
+                {
+                    "success": True,
+                    "data": [
+                        {
+                            "user_uid": user_uid,
+                            "user_name": user_name,
+                            "gender": gender,
+                        }
+                        for user_uid, user_name, gender in user_gender
+                    ],
+                }
+            ),
+            200,
+        )
+    else:
+        return jsonify(message="User gender data not found"), 404

--- a/app/blueprints/user_management/validators.py
+++ b/app/blueprints/user_management/validators.py
@@ -286,3 +286,11 @@ class GetUserLanguagesParamValidator(FlaskForm):
 
     survey_uid = IntegerField(validators=[DataRequired()])
     user_uid = IntegerField()
+
+
+class GetUserGenderParamValidator(FlaskForm):
+    class Meta:
+        csrf = False
+
+    survey_uid = IntegerField(validators=[DataRequired()])
+    user_uid = IntegerField()

--- a/tests/unit/test_user_management.py
+++ b/tests/unit/test_user_management.py
@@ -157,6 +157,31 @@ class TestUserManagement:
         )
         assert response.status_code == 200
 
+    @pytest.fixture()
+    def update_mapping_criteria_to_gender(
+        self, client, login_test_user, csrf_token, test_user_credentials
+    ):
+        # Update mapping_criteria to specified value
+        payload = {
+            "assignment_process": "Manual",
+            "language_location_mapping": False,
+            "reassignment_required": False,
+            "target_mapping_criteria": ["Gender"],
+            "surveyor_mapping_criteria": ["Gender"],
+            "supervisor_hierarchy_exists": False,
+            "supervisor_surveyor_relation": "1:many",
+            "survey_uid": 1,
+            "target_assignment_criteria": ["Location of surveyors"],
+        }
+
+        response = client.put(
+            "/api/module-questionnaire/1",
+            json=payload,
+            content_type="application/json",
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+
     @pytest.fixture
     def create_permission(self, client, login_test_user, csrf_token):
         """
@@ -401,6 +426,40 @@ class TestUserManagement:
                 "roles": [2],
                 "gender": "Male",
                 "languages": ["English", "Hindi"],
+                "is_super_admin": True,
+                "active": True,
+            },
+            content_type="application/json",
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        print(response.json)
+        assert response.status_code == 200
+
+        return response.json["user_data"]
+
+    @pytest.fixture
+    def sample_user_with_gender(
+        self,
+        client,
+        csrf_token,
+        sample_user,
+        create_roles,
+        update_mapping_criteria_to_gender,
+    ):
+        """
+        Return the user added by added_user fixture as the sample_user
+        """
+
+        user_uid = sample_user.get("user_uid")
+        response = client.put(
+            f"/api/users/{user_uid}",
+            json={
+                "survey_uid": 1,
+                "email": "updateduser@example.com",
+                "first_name": "Updated",
+                "last_name": "User",
+                "roles": [2],
+                "gender": "Male",
                 "is_super_admin": True,
                 "active": True,
             },
@@ -1407,8 +1466,16 @@ class TestUserManagement:
 
         expected_response = {
             "data": [
-                {"language": "English", "user_uid": user_uid, "user_name": "Updated User"},
-                {"language": "Hindi", "user_uid": user_uid, "user_name": "Updated User"},
+                {
+                    "language": "English",
+                    "user_uid": user_uid,
+                    "user_name": "Updated User",
+                },
+                {
+                    "language": "Hindi",
+                    "user_uid": user_uid,
+                    "user_name": "Updated User",
+                },
             ],
             "success": True,
         }
@@ -1431,6 +1498,43 @@ class TestUserManagement:
         # Fetch user languages
         response = client.get(
             "/api/user-languages",
+            query_string={"survey_uid": 1},
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+
+        print(response.json)
+
+        expected_response = {
+            "data": [
+                {
+                    "language": "Hindi",
+                    "user_uid": user_uid,
+                    "user_name": "Updated User",
+                },
+                {
+                    "language": "English",
+                    "user_uid": user_uid,
+                    "user_name": "Updated User",
+                },
+            ],
+            "success": True,
+        }
+
+        checkdiff = jsondiff.diff(expected_response, response.json)
+        assert checkdiff == {}
+
+    def test_get_user_gender(
+        self, client, login_test_user, csrf_token, sample_user_with_gender
+    ):
+        """
+        Test fetching gender for a user and a survey
+        """
+        user_uid = sample_user_with_gender.get("user_uid")
+
+        # Fetch user languages
+        response = client.get(
+            "/api/user-gender",
             query_string={"survey_uid": 1, "user_uid": user_uid},
             headers={"X-CSRF-Token": csrf_token},
         )
@@ -1440,8 +1544,39 @@ class TestUserManagement:
 
         expected_response = {
             "data": [
-                {"language": "English", "user_uid": user_uid, "user_name": "Updated User"},
-                {"language": "Hindi", "user_uid": user_uid, "user_name": "Updated User"},
+                {"gender": "Male", "user_uid": user_uid, "user_name": "Updated User"},
+            ],
+            "success": True,
+        }
+
+        checkdiff = jsondiff.diff(expected_response, response.json)
+        assert checkdiff == {}
+
+    def test_get_all_user_gender(
+        self,
+        client,
+        login_test_user,
+        csrf_token,
+        sample_user_with_gender,
+    ):
+        """
+        Test fetching gender for all users in a survey
+        """
+        user_uid = sample_user_with_gender.get("user_uid")
+
+        # Fetch user languages
+        response = client.get(
+            "/api/user-gender",
+            query_string={"survey_uid": 1},
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+
+        print(response.json)
+
+        expected_response = {
+            "data": [
+                {"gender": "Male", "user_uid": user_uid, "user_name": "Updated User"},
             ],
             "success": True,
         }


### PR DESCRIPTION
# [SS-1929] - Adding endpoint to fetch lowest level supervisors with gender

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1929

## Description, Motivation and Context

This PR adds an endpoint similar to `user-locations` and `user-languages` to fetch the gender information for a survey's lowest supervisor. This is for use in dropdowns on the mapping screen

## How Has This Been Tested?
On local

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- ~~[ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)~~
- ~~[ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.~~
- [x] I have updated the automated tests (if applicable)
- ~~[ ] I have updated the README file (if applicable)~~
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[SS-1929]: https://idinsight.atlassian.net/browse/SS-1929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ