### PR TITLE
[HOTFIX] Set Astral UV Path to Local bin

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -20,10 +20,10 @@ RUN wget -O - https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_
 
 RUN set -ex apt-get autoremove -y --purge wget && rm -rf /var/lib/apt/lists/*
 
-RUN /root/.cargo/bin/uv pip install --system --upgrade pip
+RUN ~/.local/bin/uv pip install --system --upgrade pip
 
 COPY requirements.txt /requirements.txt
-RUN /root/.cargo/bin/uv pip install --system --no-cache -r /requirements.txt
+RUN ~/.local/bin/uv pip install --system --no-cache -r /requirements.txt
 
 RUN useradd -ms /bin/bash -d ${HOME_DIR} container_user
 RUN chown -R container_user: ${HOME_DIR}


### PR DESCRIPTION
# [HOTFIX] Set Astral UV Path to Local bin

## Ticket

Fixes: No tickets created

## Description, Motivation and Context

Astral released uv 0.5 today : [Release Notes](https://github.com/astral-sh/uv/releases/tag/0.5.0)
Big change includes `~/.local/bin` as default directory for installing UV instead of `~/.cargo/bin`

We noticed errors in creating new flask images today, so we updated the docker file to use the new default directory for uv.

## How Has This Been Tested?
On local by creating a new image


## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [x] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [x] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
