### PR TITLE
[SS-1955] - MINOR, Bug Fix - SCTO repeat group detection bug

### DIFF
--- a/app/blueprints/forms/controllers.py
+++ b/app/blueprints/forms/controllers.py
@@ -624,6 +624,9 @@ def ingest_scto_form_definition(form_uid):
                 )
                 db.session.add(scto_choice_label)
 
+    # There can be nested repeat groups, so we need to keep track of the depth in order to determine if a question is part of a repeat group
+    repeat_group_depth = 0
+
     # Loop through the rows of the `survey` tab of the form definition
     for row in scto_form_definition["fieldsRowsAndColumns"][1:]:
         questions_dict = dict(zip(survey_tab_columns, row))
@@ -633,8 +636,6 @@ def ingest_scto_form_definition(form_uid):
             continue
 
         if questions_dict["name"].strip() != "":
-            # There can be nested repeat groups, so we need to keep track of the depth in order to determine if a question is part of a repeat group
-            repeat_group_depth = 0
             # Handle the questions
             list_uid = None
             list_name = None


### PR DESCRIPTION
# [SS-1955] - MINOR, Bug Fix - SCTO repeat group detection bug

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1955

## Description, Motivation and Context

The issue was the `repeat_group_depth` variable which was used to keep track of whether the variable is within a repeat group was being initialised to 0 inside the for loop. Moved that outside to fix. Pretty simple fix!

## How Has This Been Tested?
On local using hpls_r4_finance form in which we had noticed this issue

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- ~~[ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)~~
- ~~[ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.~~
- ~~[ ] I have updated the automated tests (if applicable)~~
- ~~[ ] I have updated the README file (if applicable)~~
- ~~[ ] I have updated the OpenAPI documentation (if applicable)~~

[1]: http://chris.beams.io/posts/git-commit/


[SS-1955]: https://idinsight.atlassian.net/browse/SS-1955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ