### PR TITLE
[HOTFIX] Add DELETE Api for targets

### DIFF
--- a/app/blueprints/docs/surveystream.yml
+++ b/app/blueprints/docs/surveystream.yml
@@ -6919,7 +6919,36 @@ paths:
           description: Form not found
         "422":
           description: Form errors
-  
+    delete:
+      summary: Delete targets
+      description: Delete targets for given form_uid
+      tags:
+        - Targets
+      parameters:
+        - in: query
+          name: form_uid
+          schema:
+            type: integer
+          description: Unique ID of the form
+          required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Indicates whether the request was successful
+                  message:
+                    type: string
+                    description: Targets deleted
+        "400":
+          description: Form ID is required
+
+   
   /targets/config:
     get:
       summary: Get the targets config for a form


### PR DESCRIPTION
# [HOTFIX] Add DELETE Api for targets

## Ticket

Fixes: No tickets created

## Description, Motivation and Context

Create Delete endpoint to delete all targets for a form

## How Has This Been Tested?
Local

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [x] I have updated the automated tests (if applicable)
- [ ] I have updated the README file (if applicable)
- [x] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
