### PR TITLE
[HOTFIX] Fix space issue while linking choice name with question name

### DIFF
--- a/app/blueprints/forms/controllers.py
+++ b/app/blueprints/forms/controllers.py
@@ -648,7 +648,7 @@ def ingest_scto_form_definition(form_uid):
                 "select_one",
                 "select_multiple",
             ]:
-                list_name = questions_dict["type"].strip().split(" ")[1]
+                list_name = questions_dict["type"].strip().split(" ")[-1]
                 list_uid = (
                     SCTOChoiceList.query.filter_by(
                         form_uid=form_uid, list_name=list_name


### PR DESCRIPTION
# [HOTFIX] Fix space issue while linking choice name with question name

## Ticket

Fixes: No tickets created

## Description, Motivation and Context

During DG survey configs we noticed that scto refresh endpoint giving an error.

One of the question had multiple spaces between 'select_one' and 'choice_name', this lead to choice list name coming as null in our split function.
Fixed the split function to get last charchter in list instead of 2nd one to fix this error.


## How Has This Been Tested?
Local


## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
