### PR TITLE
[SS-2053, MINOR] - Removing prod tracker and hiring from module counts to avoid confusion

### DIFF
--- a/app/blueprints/surveys/controllers.py
+++ b/app/blueprints/surveys/controllers.py
@@ -310,6 +310,11 @@ def get_survey_config_status(survey_uid):
                 # this module is not mandatory
                 optional = True
                 num_optional += 1
+
+            elif status.name in ["Productivity tracker", "Hiring"]:
+                # these modules don't have configurations on the webapp
+                # so we don't include them in counts
+                pass
             else:
                 optional = False
 


### PR DESCRIPTION
# [SS-2053, MINOR] - Removing prod tracker and hiring from module counts to avoid confusion

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-2053

## Description, Motivation and Context

Since these two modules are hidden on the WebApp, removing these from the progress tracker counts.

## How Has This Been Tested?
On local using frontend change [here](https://github.com/IDinsight/surveystream_react_app/pull/336)

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- ~~[ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)~~
- ~~[ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.~~
- ~~[ ] I have updated the automated tests (if applicable)~~
- ~~[ ] I have updated the README file (if applicable)~~
- ~~[ ] I have updated the OpenAPI documentation (if applicable)~~

[1]: http://chris.beams.io/posts/git-commit/
