### PR TITLE
[SS-2065] - Minor change to shift admin forms to survey information section

### DIFF
--- a/app/blueprints/surveys/controllers.py
+++ b/app/blueprints/surveys/controllers.py
@@ -274,7 +274,7 @@ def get_survey_config_status(survey_uid):
                     module_status,
                 )
 
-            if calculated_optional_flag == False:
+            if calculated_optional_flag is False:
                 # These modules are mandatory
                 data["Survey Information"].append(
                     {
@@ -285,7 +285,7 @@ def get_survey_config_status(survey_uid):
                 )
 
                 num_modules += 1
-                if module_status == "Done":
+                if module_status in ["Done", "Live"]:
                     num_completed += 1
                 elif module_status == "In Progress":
                     num_in_progress += 1
@@ -312,12 +312,11 @@ def get_survey_config_status(survey_uid):
 
             optional = False  # Since this list will only have selected modules and selected modules are mandatory
             if status.name == "Assignments Column Configuration":
-                # this module is not mandatory
+                # "Assignments Column Configuration" - is not treated as a separate module
+                # in the webapp, so we don't include it
                 optional = True
-                num_optional += 1
-
             elif status.name in ["Productivity Tracker", "Surveyor Hiring"]:
-                # these modules don't have configurations on the webapp
+                # "Productivity Tracker", "Surveyor Hiring" - don't have configurations on the webapp
                 # so we don't include them in counts
                 pass
             else:

--- a/tests/unit/test_module_selection.py
+++ b/tests/unit/test_module_selection.py
@@ -383,7 +383,7 @@ class TestModuleSelection:
                     "num_in_progress_incomplete": 1,
                     "num_not_started": 5,
                     "num_error": 0,
-                    "num_optional": 3,
+                    "num_optional": 2,
                 }
             },
             "success": True,
@@ -494,7 +494,7 @@ class TestModuleSelection:
                     "num_in_progress_incomplete": 1,
                     "num_not_started": 6,
                     "num_error": 0,
-                    "num_optional": 2,
+                    "num_optional": 1,
                 }
             },
             "success": True,

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1925,7 +1925,7 @@ class TestNotifications:
                     "num_in_progress_incomplete": 1,
                     "num_not_started": 1,
                     "num_error": 3,
-                    "num_optional": 1,
+                    "num_optional": 0,
                 },
             },
         }


### PR DESCRIPTION
# [SS-2065] - Minor change to shift admin forms to survey information section

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-2065

## Description, Motivation and Context

As per copy and ui/ux [discussions](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2256994315/Technical+Discussion+-+26+Mar+2025) on 26/05, making changes needed to shift Admin Forms module to the survey information section.

Also added change to remove 'Assignment Column Configuration' from the module list.

## How Has This Been Tested?
On local

## To-do before merge
None

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- ~~[ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)~~
- ~~[ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.~~
- [x] I have updated the automated tests (if applicable)
- ~~[ ] I have updated the README file (if applicable)~~
- ~~[ ] I have updated the OpenAPI documentation (if applicable)~~

[1]: http://chris.beams.io/posts/git-commit/


[SS-2065]: https://idinsight.atlassian.net/browse/SS-2065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ