### PR TITLE
[SS-2069] Fix Nan value handling for targets custom fields

### DIFF
--- a/app/blueprints/targets/utils.py
+++ b/app/blueprints/targets/utils.py
@@ -559,6 +559,8 @@ class TargetsUpload:
                     ).first()
 
                     for field_name, field_value in record["custom_fields"].items():
+                        if pd.isna(field_value) or field_value == "nan":
+                            field_value = None
                         target_record.custom_fields[field_name] = field_value
 
             if records_to_insert:


### PR DESCRIPTION
# [SS-2069] Fix Nan value handling for targets' custom fields

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-2069

## Description, Motivation and Context

In Dynamic Targets, if the custom field value was Nan, api was running into an error since the Postgres JSON column can not have a nan value..

Added validation for non-values before correctly updating it on Custom fields column.

## How Has This Been Tested?
Local, UHC Patients survey

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[SS-2069]: https://idinsight.atlassian.net/browse/SS-2069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ