### PR TITLE
[SS-2074] Allow media fields when fetching scto questions

### DIFF
--- a/app/blueprints/media_files/controllers.py
+++ b/app/blueprints/media_files/controllers.py
@@ -102,61 +102,6 @@ def create_media_files_config(validated_payload):
     """
     form_uid = validated_payload.form_uid.data
 
-    # Check if mapping criteria is valid
-    if validated_payload.mapping_criteria.data:
-        from app.blueprints.targets.models import Target
-
-        mapping_criteria = validated_payload.mapping_criteria.data
-        # Check if any targets exist for this form
-        targets = Target.query.filter(Target.form_uid == form_uid).all()
-        if len(targets) == 0:
-            return (
-                jsonify(
-                    {
-                        "success": False,
-                        "error": {"message": "No targets exist for this form"},
-                    }
-                ),
-                422,
-            )
-        if mapping_criteria == "location":
-            # Check if all targets have location
-            targets_without_location = Target.query.filter(
-                Target.form_uid == form_uid,
-                Target.location_uid.is_(None),
-            ).all()
-
-            if len(targets_without_location) > 0:
-                return (
-                    jsonify(
-                        {
-                            "success": False,
-                            "error": {
-                                "message": "All targets must have a location for mapping criteria 'location'"
-                            },
-                        }
-                    ),
-                    422,
-                )
-        elif mapping_criteria == "language":
-            # Check if all targets have language
-            targets_without_language = Target.query.filter(
-                Target.form_uid == form_uid,
-                Target.language.is_(None),
-            ).all()
-            if len(targets_without_language) > 0:
-                return (
-                    jsonify(
-                        {
-                            "success": False,
-                            "error": {
-                                "message": "All targets must have a language for mapping criteria 'language'"
-                            },
-                        }
-                    ),
-                    422,
-                )
-
     new_config = MediaFilesConfig(
         form_uid=form_uid,
         file_type=validated_payload.file_type.data,
@@ -212,62 +157,6 @@ def update_media_files_config(media_files_config_uid, validated_payload):
     Method to save media files config for a form
     """
     media_files_config = MediaFilesConfig.query.get_or_404(media_files_config_uid)
-
-    form_uid = media_files_config.form_uid
-    # Check if mapping criteria is valid
-    if validated_payload.mapping_criteria.data:
-        from app.blueprints.targets.models import Target
-
-        mapping_criteria = validated_payload.mapping_criteria.data
-        # Check if any targets exist for this form
-        targets = Target.query.filter(Target.form_uid == form_uid).all()
-        if len(targets) == 0:
-            return (
-                jsonify(
-                    {
-                        "success": False,
-                        "error": {"message": "No targets exist for this form"},
-                    }
-                ),
-                422,
-            )
-        if mapping_criteria == "location":
-            # Check if all targets have location
-            targets_without_location = Target.query.filter(
-                Target.form_uid == form_uid,
-                Target.location_uid.is_(None),
-            ).all()
-
-            if len(targets_without_location) > 0:
-                return (
-                    jsonify(
-                        {
-                            "success": False,
-                            "error": {
-                                "message": "All targets must have a location for mapping criteria 'location'"
-                            },
-                        }
-                    ),
-                    422,
-                )
-        elif mapping_criteria == "language":
-            # Check if all targets have language
-            targets_without_language = Target.query.filter(
-                Target.form_uid == form_uid,
-                Target.language.is_(None),
-            ).all()
-            if len(targets_without_language) > 0:
-                return (
-                    jsonify(
-                        {
-                            "success": False,
-                            "error": {
-                                "message": "All targets must have a language for mapping criteria 'language'"
-                            },
-                        }
-                    ),
-                    422,
-                )
 
     media_files_config.file_type = validated_payload.file_type.data
     media_files_config.source = validated_payload.source.data


### PR DESCRIPTION
# [SS-2074] Allow media fields when fetching scto questions

## Ticket

Linked to: https://idinsight.atlassian.net/browse/SS-2074

## Description, Motivation and Context

Image and audio fields were not fetched when surveycto questions were pulled from the database.
With recent changes in media fields for wide outputs, these fields have raised questions.

## How Has This Been Tested?
Local

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[SS-2074]: https://idinsight.atlassian.net/browse/SS-2074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ