### PR TITLE
[SS-1892] Parent form Update server name and timezone for admin and dq forms

### DIFF
--- a/app/blueprints/forms/controllers.py
+++ b/app/blueprints/forms/controllers.py
@@ -243,6 +243,7 @@ def update_form(form_uid, validated_payload):
         )
 
     try:
+
         Form.query.filter_by(form_uid=form_uid).update(
             {
                 Form.scto_form_id: validated_payload.scto_form_id.data,
@@ -264,6 +265,17 @@ def update_form(form_uid, validated_payload):
             },
             synchronize_session="fetch",
         )
+        if validated_payload.form_type.data == "parent":
+            form = Form.query.filter_by(form_uid=form_uid).first()
+            # Update surveycto scto_server_name and timezone for all forms of this survey
+            Form.query.filter_by(survey_uid=form.survey_uid).update(
+                {
+                    Form.scto_server_name: validated_payload.scto_server_name.data,
+                    Form.tz_name: validated_payload.tz_name.data,
+                },
+                synchronize_session=False,
+            )
+
         db.session.commit()
     except IntegrityError:
         db.session.rollback()

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -8,6 +8,7 @@ from utils import (
     set_target_assignable_status,
     update_logged_in_user_roles,
 )
+
 from app import db
 
 
@@ -226,7 +227,7 @@ class TestForms:
             "form_type": "parent",
             "parent_form_uid": None,
             "dq_form_type": None,
-            "number_of_attempts":7,
+            "number_of_attempts": 7,
         }
 
         response = client.post(
@@ -1629,7 +1630,11 @@ class TestForms:
             "data": [
                 {"config_status": "Done", "module_id": 1, "survey_uid": 1},
                 {"config_status": "Not Started", "module_id": 2, "survey_uid": 1},
-                {"config_status": "In Progress - Incomplete", "module_id": 3, "survey_uid": 1},
+                {
+                    "config_status": "In Progress - Incomplete",
+                    "module_id": 3,
+                    "survey_uid": 1,
+                },
                 {"config_status": "Not Started", "module_id": 4, "survey_uid": 1},
             ],
             "success": True,
@@ -1696,7 +1701,11 @@ class TestForms:
             "data": [
                 {"config_status": "Done", "module_id": 1, "survey_uid": 1},
                 {"config_status": "Done", "module_id": 2, "survey_uid": 1},
-                {"config_status": "In Progress - Incomplete", "module_id": 3, "survey_uid": 1},
+                {
+                    "config_status": "In Progress - Incomplete",
+                    "module_id": 3,
+                    "survey_uid": 1,
+                },
                 {"config_status": "Done", "module_id": 4, "survey_uid": 1},
                 {
                     "config_status": "In Progress - Incomplete",
@@ -1748,7 +1757,11 @@ class TestForms:
             "data": [
                 {"config_status": "Done", "module_id": 1, "survey_uid": 1},
                 {"config_status": "Done", "module_id": 2, "survey_uid": 1},
-                {"config_status": "In Progress - Incomplete", "module_id": 3, "survey_uid": 1},
+                {
+                    "config_status": "In Progress - Incomplete",
+                    "module_id": 3,
+                    "survey_uid": 1,
+                },
                 {"config_status": "Done", "module_id": 4, "survey_uid": 1},
                 {"config_status": "In Progress", "module_id": 11, "survey_uid": 1},
                 {"config_status": "Not Started", "module_id": 18, "survey_uid": 1},
@@ -1771,7 +1784,11 @@ class TestForms:
             "data": [
                 {"config_status": "Done", "module_id": 1, "survey_uid": 1},
                 {"config_status": "Done", "module_id": 2, "survey_uid": 1},
-                {"config_status": "In Progress - Incomplete", "module_id": 3, "survey_uid": 1},
+                {
+                    "config_status": "In Progress - Incomplete",
+                    "module_id": 3,
+                    "survey_uid": 1,
+                },
                 {"config_status": "Done", "module_id": 4, "survey_uid": 1},
                 {"config_status": "Not Started", "module_id": 11, "survey_uid": 1},
                 {
@@ -1817,10 +1834,121 @@ class TestForms:
             "data": [
                 {"config_status": "Done", "module_id": 1, "survey_uid": 1},
                 {"config_status": "Done", "module_id": 2, "survey_uid": 1},
-                {"config_status": "In Progress - Incomplete", "module_id": 3, "survey_uid": 1},
+                {
+                    "config_status": "In Progress - Incomplete",
+                    "module_id": 3,
+                    "survey_uid": 1,
+                },
                 {"config_status": "Done", "module_id": 4, "survey_uid": 1},
                 {"config_status": "Not Started", "module_id": 11, "survey_uid": 1},
                 {"config_status": "In Progress", "module_id": 18, "survey_uid": 1},
             ],
             "success": True,
         }
+
+    def test_update_parent_form_server_name(
+        self,
+        client,
+        login_test_user,
+        create_admin_form,
+        csrf_token,
+        user_with_admin_forms_permissions,
+        request,
+    ):
+        """
+        Test update server name and timezone for parent form
+
+        Expect: Server name and timezone is updated both for parent and admin form
+        """
+        user_fixture, expected_permission = user_with_admin_forms_permissions
+        request.getfixturevalue(user_fixture)
+
+        payload = {
+            "scto_form_id": "test_scto_input_output",
+            "form_name": "Agrifieldnet Main Form",
+            "tz_name": "America/New_York",
+            "scto_server_name": "updated_server",
+            "encryption_key_shared": True,
+            "server_access_role_granted": True,
+            "server_access_allowed": True,
+            "form_type": "parent",
+            "parent_form_uid": None,
+            "dq_form_type": None,
+            "number_of_attempts": 7,
+        }
+
+        response = client.put(
+            "/api/forms/1",
+            json=payload,
+            content_type="application/json",
+            headers={"X-CSRF-Token": csrf_token},
+        )
+
+        if expected_permission:
+            assert response.status_code == 200
+
+            # Check parent form updated correctly
+            response = client.get("/api/forms/1")
+
+            assert response.status_code == 200
+
+            expected_response = {
+                "success": True,
+                "data": {
+                    "form_uid": 1,
+                    "survey_uid": 1,
+                    "scto_form_id": "test_scto_input_output",
+                    "form_name": "Agrifieldnet Main Form",
+                    "form_type": "parent",
+                    "dq_form_type": None,
+                    "admin_form_type": None,
+                    "parent_form_uid": None,
+                    "tz_name": "America/New_York",
+                    "scto_server_name": "updated_server",
+                    "encryption_key_shared": True,
+                    "server_access_role_granted": True,
+                    "server_access_allowed": True,
+                    "last_ingested_at": None,
+                    "number_of_attempts": 7,
+                    "parent_scto_form_id": None,
+                },
+            }
+
+            assert response.json == expected_response
+
+            # Check admin form also updated
+            response = client.get("/api/forms/2")
+            print(response.json)
+
+            assert response.status_code == 200
+            expected_response = {
+                "success": True,
+                "data": {
+                    "form_uid": 2,
+                    "survey_uid": 1,
+                    "scto_form_id": "test_scto_admin",
+                    "form_name": "Agrifieldnet Bikelog Form",
+                    "form_type": "admin",
+                    "dq_form_type": None,
+                    "admin_form_type": "bikelog",
+                    "parent_form_uid": None,
+                    "tz_name": "America/New_York",
+                    "scto_server_name": "updated_server",
+                    "encryption_key_shared": True,
+                    "server_access_role_granted": True,
+                    "server_access_allowed": True,
+                    "last_ingested_at": None,
+                    "number_of_attempts": None,
+                    "parent_scto_form_id": None,
+                },
+            }
+            assert response.json == expected_response
+
+        else:
+            assert response.status_code == 403
+            expected_response = {
+                "success": False,
+                "error": "User does not have the required permission: WRITE Data Quality Forms, WRITE Admin Forms",
+            }
+            checkdiff = jsondiff.diff(expected_response, response.json)
+            assert checkdiff == {}


### PR DESCRIPTION
# [SS-1892] Parent form Update server name and timezone for admin and dq forms

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-1892

## Description, Motivation and Context

Admin/DQ forms store server and timezone details based on the current details of parent form of survey.
If parent form details are updated, they should be reflected in Admin/DQ forms.

Updated the PUT endpoint of forms to update server and timezone details of all form if the request contains a parent form.

## How Has This Been Tested?
Local, added a new test

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [x] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
- [x] I have written [good commit messages][1]
- [ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [x] I have updated the automated tests (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[SS-1892]: https://idinsight.atlassian.net/browse/SS-1892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ