### PR TITLE
[SS-2028] Delete User Mapping config if mapping  criteria changes

### DIFF
--- a/app/blueprints/module_questionnaire/controllers.py
+++ b/app/blueprints/module_questionnaire/controllers.py
@@ -1,6 +1,3 @@
-from flask import jsonify
-from sqlalchemy.dialects.postgresql import insert as pg_insert
-
 from app import db
 from app.utils.utils import (
     custom_permissions_required,
@@ -8,6 +5,8 @@ from app.utils.utils import (
     update_module_status_after_request,
     validate_payload,
 )
+from flask import jsonify
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from .models import ModuleQuestionnaire
 from .routes import module_questionnaire_bp
@@ -42,37 +41,31 @@ def update_survey_module_questionnaire(survey_uid, validated_payload):
         survey_uid=survey_uid
     ).first()
     if existing_module_questionnaire:
-        if (
-            existing_module_questionnaire.target_mapping_criteria
-            != validated_payload.target_mapping_criteria.data
-            or existing_module_questionnaire.surveyor_mapping_criteria
-            != validated_payload.surveyor_mapping_criteria.data
-        ):
-            from app.blueprints.forms.models import Form
-            from app.blueprints.mapping.models import UserMappingConfig
+        from app.blueprints.forms.models import Form
+        from app.blueprints.mapping.models import UserMappingConfig
 
-            # Delete all user mapping configs for this survey
-            main_form = Form.query.filter_by(
-                survey_uid=survey_uid, form_type="parent"
-            ).first()
+        # Delete all user mapping configs for this survey
+        main_form = Form.query.filter_by(
+            survey_uid=survey_uid, form_type="parent"
+        ).first()
 
-            if main_form:
-                main_form_uid = main_form.form_uid
-                if (
-                    existing_module_questionnaire.target_mapping_criteria
-                    != validated_payload.target_mapping_criteria.data
-                ):
-                    UserMappingConfig.query.filter_by(
-                        form_uid=main_form_uid, mapping_type="target"
-                    ).delete(synchronize_session=False)
+        if main_form:
+            main_form_uid = main_form.form_uid
+            if (
+                existing_module_questionnaire.target_mapping_criteria
+                != validated_payload.target_mapping_criteria.data
+            ):
+                UserMappingConfig.query.filter_by(
+                    form_uid=main_form_uid, mapping_type="target"
+                ).delete(synchronize_session=False)
 
-                if (
-                    existing_module_questionnaire.surveyor_mapping_criteria
-                    != validated_payload.surveyor_mapping_criteria.data
-                ):
-                    UserMappingConfig.query.filter_by(
-                        form_uid=main_form_uid, mapping_type="surveyor"
-                    ).delete(synchronize_session=False)
+            if (
+                existing_module_questionnaire.surveyor_mapping_criteria
+                != validated_payload.surveyor_mapping_criteria.data
+            ):
+                UserMappingConfig.query.filter_by(
+                    form_uid=main_form_uid, mapping_type="surveyor"
+                ).delete(synchronize_session=False)
 
     # do upsert
     statement = (


### PR DESCRIPTION
# [SS-2028] Delete User Mapping config if mapping  criteria changes

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-2028

## Description, Motivation and Context

Delete User Mapping config based on mapping criteria changes

## How Has This Been Tested?
Local

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [ ] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have written [good commit messages][1]
- [ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[SS-2028]: https://idinsight.atlassian.net/browse/SS-2028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ