### PR TITLE
Email Delivery Report : Add a new endpoint for Enumerator status report

### DIFF
--- a/app/blueprints/emails/controllers.py
+++ b/app/blueprints/emails/controllers.py
@@ -45,6 +45,7 @@ from .validators import (
     EmailConfigValidator,
     EmailDeliveryReportBulkValidator,
     EmailDeliveryReportQueryValidator,
+    EmailEnumeratorReportQueryValidator,
     EmailGsheetSourceParamValidator,
     EmailGsheetSourcePatchParamValidator,
     EmailScheduleQueryParamValidator,
@@ -164,10 +165,9 @@ def get_email_details(validated_query_params):
     config_data = []
     for email_config in email_configs:
         email_config_dict = email_config.to_dict()
-        email_config_dict[
-            "email_source_columns"
-        ] = email_config.email_source_columns + get_default_email_variable_names(
-            form_uid
+        email_config_dict["email_source_columns"] = (
+            email_config.email_source_columns
+            + get_default_email_variable_names(form_uid)
         )
         config_data.append(
             {
@@ -243,10 +243,9 @@ def get_email_configs(validated_query_params):
     config_data = []
     for email_config in email_configs:
         email_config_dict = email_config.to_dict()
-        email_config_dict[
-            "email_source_columns"
-        ] = email_config.email_source_columns + get_default_email_variable_names(
-            form_uid
+        email_config_dict["email_source_columns"] = (
+            email_config.email_source_columns
+            + get_default_email_variable_names(form_uid)
         )
 
         config_data.append(email_config_dict)
@@ -283,10 +282,9 @@ def get_email_config(email_config_uid):
         )
 
     email_config_dict = email_config.to_dict()
-    email_config_dict[
-        "email_source_columns"
-    ] = email_config.email_source_columns + get_default_email_variable_names(
-        email_config.form_uid
+    email_config_dict["email_source_columns"] = (
+        email_config.email_source_columns
+        + get_default_email_variable_names(email_config.form_uid)
     )
 
     response = jsonify(
@@ -942,11 +940,11 @@ def create_email_template(validated_payload):
             .first()
         ).form_uid
         update_module_status(15, form_uid=form_uid)
-        
+
     except Exception as e:
         db.session.rollback()
         return jsonify({"error": str(e)}), 500
-    
+
     return (
         jsonify(
             {
@@ -1066,7 +1064,7 @@ def create_email_template_bulk(validated_payload):
     except Exception as e:
         db.session.rollback()
         return jsonify({"error": str(e)}), 500
-    
+
     return (
         jsonify(
             {
@@ -1672,25 +1670,33 @@ def get_email_schedule_report(validated_query_params):
 
     else:
         result = []
+        latest_report = max(
+            email_delivery_reports, key=lambda report: report.email_delivery_report_uid
+        )
         for email_delivery_report in email_delivery_reports:
             email_delivery_report_dict = email_delivery_report.to_dict()
-            email_enumerator_status = get_surveyor_details(
-                form_uid, email_delivery_report.email_delivery_report_uid
-            )
+            if email_delivery_report.email_delivery_report_uid == (
+                latest_report.email_delivery_report_uid
+            ):
+                email_enumerator_status = get_surveyor_details(
+                    form_uid, email_delivery_report.email_delivery_report_uid
+                )
 
-            email_delivery_report_dict["enumerator_status"] = [
-                {
-                    "enumerator_id": enum[0],
-                    "enumerator_name": enum[1],
-                    "enumerator_email": enum[2],
-                    "supervisor_name": enum[3],
-                    "supervisor_email": enum[4],
-                    "status": enum[5],
-                    "error_message": enum[6],
-                }
-                for enum in email_enumerator_status
-            ]
+                email_delivery_report_dict["enumerator_status"] = [
+                    {
+                        "enumerator_id": enum[0],
+                        "enumerator_name": enum[1],
+                        "enumerator_email": enum[2],
+                        "supervisor_name": enum[3],
+                        "supervisor_email": enum[4],
+                        "status": enum[5],
+                        "error_message": enum[6],
+                    }
+                    for enum in email_enumerator_status
+                ]
 
+            else:
+                email_delivery_report_dict["enumerator_status"] = []
             result.append(email_delivery_report_dict)
 
         return (
@@ -1702,6 +1708,51 @@ def get_email_schedule_report(validated_query_params):
             ),
             200,
         )
+
+
+@emails_bp.route("/enumerator_report", methods=["GET"])
+@logged_in_active_user_required
+@validate_query_params(EmailEnumeratorReportQueryValidator)
+@custom_permissions_required("READ Emails", "query", "email_config_uid")
+def get_email_enumerator_status_report(validated_query_params):
+    """Function to get email delivery report for email schedule or trigger"""
+    email_delivery_report_uid = validated_query_params.email_delivery_report_uid.data
+    email_delivery_report = EmailDeliveryReport.query.get_or_404(
+        email_delivery_report_uid
+    )
+    email_config_uid = validated_query_params.email_config_uid.data
+    form_uid = EmailConfig.query.get_or_404(email_config_uid).form_uid
+
+    result = []
+    email_delivery_report_dict = email_delivery_report.to_dict()
+    email_enumerator_status = get_surveyor_details(
+        form_uid, email_delivery_report.email_delivery_report_uid
+    )
+
+    email_delivery_report_dict["enumerator_status"] = [
+        {
+            "enumerator_id": enum[0],
+            "enumerator_name": enum[1],
+            "enumerator_email": enum[2],
+            "supervisor_name": enum[3],
+            "supervisor_email": enum[4],
+            "status": enum[5],
+            "error_message": enum[6],
+        }
+        for enum in email_enumerator_status
+    ]
+
+    result.append(email_delivery_report_dict)
+
+    return (
+        jsonify(
+            {
+                "success": True,
+                "data": result,
+            }
+        ),
+        200,
+    )
 
 
 @emails_bp.route("/tablecatalog/schedules", methods=["GET"])

--- a/app/blueprints/emails/utils.py
+++ b/app/blueprints/emails/utils.py
@@ -402,6 +402,12 @@ def get_surveyor_details(form_uid, email_delivery_report_uid):
             SurveyorForm.form_uid == form_uid,
             EmailEnumeratorDeliveryStatus.email_delivery_report_uid
             == email_delivery_report_uid,
+            db.or_(
+                EmailEnumeratorDeliveryStatus.error_message.is_(None),
+                EmailEnumeratorDeliveryStatus.error_message.notlike(
+                    "No data available%"
+                ),
+            ),
         )
     )
 

--- a/app/blueprints/emails/validators.py
+++ b/app/blueprints/emails/validators.py
@@ -348,3 +348,11 @@ class EmailDeliveryReportQueryValidator(FlaskForm):
         AnyOf(["trigger", "schedule"], message="Invalid slot type"),
         default=None,
     )
+
+
+class EmailEnumeratorReportQueryValidator(FlaskForm):
+    class Meta:
+        csrf = False
+
+    email_config_uid = IntegerField(validators=[DataRequired()])
+    email_delivery_report_uid = IntegerField(validators=[DataRequired()])

--- a/tests/unit/test_emails.py
+++ b/tests/unit/test_emails.py
@@ -4519,8 +4519,6 @@ class TestEmails:
         print(get_response.status_code)
         print(get_response.json)
 
-        assert get_response.status_code == 200
-
         if expected_permission:
             assert get_response.status_code == 200
 

--- a/tests/unit/test_emails.py
+++ b/tests/unit/test_emails.py
@@ -4494,3 +4494,86 @@ class TestEmails:
             )
 
             assert checkdiff == {}
+
+    def test_email_get_enumerator_report(
+        self,
+        client,
+        csrf_token,
+        create_email_delivery_report,
+        create_manual_email_trigger,
+        user_permissions,
+        request,
+    ):
+        user_fixture, expected_permission = user_permissions
+        request.getfixturevalue(user_fixture)
+
+        get_response = client.get(
+            "/api/emails/enumerator_report",
+            query_string={
+                "email_delivery_report_uid": 1,
+                "email_config_uid": 1,
+            },
+            content_type="application/json",
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        print(get_response.status_code)
+        print(get_response.json)
+
+        assert get_response.status_code == 200
+
+        if expected_permission:
+            assert get_response.status_code == 200
+
+            expected_response = {
+                "data": [
+                    {
+                        "delivery_time": "2021-06-01 00:00:00",
+                        "email_delivery_report_uid": 1,
+                        "email_schedule_uid": 1,
+                        "enumerator_status": [
+                            {
+                                "enumerator_email": "eric.dodge@idinsight.org",
+                                "enumerator_id": "0294612",
+                                "enumerator_name": "Eric Dodge",
+                                "error_message": None,
+                                "status": "sent",
+                                "supervisor_email": "newuser3@example.com",
+                                "supervisor_name": "John Doe",
+                            },
+                            {
+                                "enumerator_email": "jahnavi.meher@idinsight.org",
+                                "enumerator_id": "0294613",
+                                "enumerator_name": "Jahnavi Meher",
+                                "error_message": "Email delivery failed",
+                                "status": "failed",
+                                "supervisor_email": "newuser3@example.com",
+                                "supervisor_name": "John Doe",
+                            },
+                        ],
+                        "manual_email_trigger_uid": None,
+                        "slot_date": "Tue, 01 Jun 2021 00:00:00 GMT",
+                        "slot_time": "00:00:00",
+                        "slot_type": "schedule",
+                    }
+                ],
+                "success": True,
+            }
+
+            checkdiff = jsondiff.diff(
+                expected_response,
+                get_response.json,
+            )
+            assert checkdiff == {}
+        else:
+            assert get_response.status_code == 403
+            expected_response = {
+                "error": "User does not have the required permission: READ Emails",
+                "success": False,
+            }
+
+            checkdiff = jsondiff.diff(
+                expected_response,
+                get_response.json,
+            )
+
+            assert checkdiff == {}


### PR DESCRIPTION
# [SS-2219] Email Delivery Report : Add a new endpoint for Enumerator status report

## Ticket

Fixes: https://idinsight.atlassian.net/browse/SS-2219

## Description, Motivation and Context

Added a new endpoint to get the enumerator status report for email delivery report uid.
Allows frontend to fetch enumerator-level report whenever user changes the dropdown date on email delivery report.

Removed those enumerators from email delivery report for which no data was found in table to send email.

## How Has This Been Tested?
Local

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [ ] My code follows the style guidelines and [standard practices](https://idinsight.atlassian.net/wiki/spaces/DOD/pages/2199912628/Flask+Development+Standards) for this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have written [good commit messages][1]
- [ ] I have created migration scripts from the latest dev changes. This will prevent migration script version conflicts (if applicable)
- [ ] I have scrutinized and edited the migration script with reference to [changes Alembic won't auto-detect](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect) (if applicable). Note that this includes manually adding the creation of new `CHECK` constraints.
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated the OpenAPI documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/


[SS-2219]: https://idinsight.atlassian.net/browse/SS-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ